### PR TITLE
Add test suite validation

### DIFF
--- a/src/etos_api/lib/validator.py
+++ b/src/etos_api/lib/validator.py
@@ -100,11 +100,19 @@ class Recipe(BaseModel):
     ):  # Pydantic requires cls. pylint:disable=no-self-argument
         """Validate the constraints fields for each recipe.
 
-        This is a separate method where the validation is done manually.
-        That is because the error messages from pydantic are not clear enough
-        when using a Union check on the models.
+        Validation is done manually because error messages from pydantic
+        are not clear enough when using a Union check on the models.
         Pydantic does not check the number of unions either, which is something
         that is required for ETOS.
+
+        :raises ValueError: if there are too many or too few constraints.
+        :raises TypeError: If an unknown constraint is detected.
+        :raises ValidationError: If constraint model does not validate.
+
+        :param value: The current constraint that is being validated.
+        :type value: Any
+        :return: Same as value, if validated.
+        :rtype: Any
         """
         count = dict.fromkeys(cls.__constraint_models.keys(), 0)
         for constraint in value:

--- a/src/etos_api/lib/validator.py
+++ b/src/etos_api/lib/validator.py
@@ -1,0 +1,173 @@
+# Copyright 2020 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ETOS API suite validator module."""
+import logging
+from uuid import UUID
+from typing import Union, List
+from pydantic import BaseModel, validator, ValidationError, constr, conlist
+import requests
+
+
+class Environment(BaseModel):
+    """ETOS suite definion 'ENVIRONMENT' constraint."""
+
+    key: str
+    value: dict
+
+
+class Command(BaseModel):
+    """ETOS suite definion 'COMMAND' constraint."""
+
+    key: str
+    value: constr(min_length=1)
+
+
+class Checkout(BaseModel):
+    """ETOS suite definion 'CHECKOUT' constraint."""
+
+    key: str
+    value: conlist(str, min_items=1)
+
+
+class Parameters(BaseModel):
+    """ETOS suite definion 'PARAMETERS' constraint."""
+
+    key: str
+    value: dict
+
+
+class Execute(BaseModel):
+    """ETOS suite definion 'EXECUTE' constraint."""
+
+    key: str
+    value: List[str]
+
+
+class TestRunner(BaseModel):
+    """ETOS suite definion 'TEST_RUNNER' constraint."""
+
+    key: str
+    value: constr(min_length=1)
+
+
+class TestCase(BaseModel):
+    """ETOS suite definion 'testCase' field."""
+
+    id: str
+    tracker: str
+    url: str
+
+
+class Constraint(BaseModel):
+    """ETOS suite definion 'constraints' field."""
+
+    key: str
+    value: Union[str, list, dict]  # pylint:disable=unsubscriptable-object
+
+
+class Recipe(BaseModel):
+    """ETOS suite definion 'recipes' field."""
+
+    constraints: List[Constraint]
+    id: UUID
+    testCase: TestCase
+
+    __constraint_models = {
+        "ENVIRONMENT": Environment,
+        "COMMAND": Command,
+        "CHECKOUT": Checkout,
+        "PARAMETERS": Parameters,
+        "EXECUTE": Execute,
+        "TEST_RUNNER": TestRunner,
+    }
+
+    @validator("constraints")
+    def validate_constraints(
+        cls, value
+    ):  # Pydantic requires cls. pylint:disable=no-self-argument
+        """Validate the constraints fields for each recipe.
+
+        This is a separate method where the validation is done manually.
+        That is because the error messages from pydantic are not clear enough
+        when using a Union check on the models.
+        Pydantic does not check the number of unions either, which is something
+        that is required for ETOS.
+        """
+        count = dict.fromkeys(cls.__constraint_models.keys(), 0)
+        for constraint in value:
+            model = cls.__constraint_models.get(constraint.key)
+            if model is None:
+                raise TypeError(
+                    "Unknown key %r, valid keys: %r"
+                    % (constraint.key, tuple(cls.__constraint_models.keys()))
+                )
+            try:
+                model(**constraint.dict())
+            except ValidationError as exception:
+                raise ValueError(str(exception)) from exception
+            count[constraint.key] += 1
+        more_than_one = [key for key, number in count.items() if number > 1]
+        if more_than_one:
+            raise ValueError(
+                "Too many instances of keys %r. Only 1 allowed." % more_than_one
+            )
+        missing = [key for key, number in count.items() if number == 0]
+        if missing:
+            raise ValueError(
+                "Too few instances of keys %r. At least 1 required." % missing
+            )
+        return value
+
+
+class Suite(BaseModel):
+    """ETOS base suite definition."""
+
+    name: str
+    priority: int
+    recipes: List[Recipe]
+
+
+class SuiteValidator:  # pylint:disable=too-few-public-methods
+    """Validate ETOS suite definitions to make sure they are executable."""
+
+    logger = logging.getLogger(__name__)
+
+    def __init__(self, params):
+        """Initialize validator.
+
+        :param params: Parameter instance.
+        :type params: :obj:`etos_api.lib.params.Params`
+        """
+        self.params = params
+
+    def _download_suite(self):
+        """Attempt to download suite."""
+        try:
+            suite = requests.get(self.params.test_suite)
+            suite.raise_for_status()
+        except Exception as exception:  # pylint:disable=broad-except
+            raise AssertionError(
+                "Unable to download suite from %r" % self.params.test_suite
+            ) from exception
+        return suite.json()
+
+    def validate(self):
+        """Validate the ETOS suite definition.
+
+        :raises ValidationError: If the suite did not validate.
+        """
+        downloaded_suite = self._download_suite()
+        assert Suite(**downloaded_suite)

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2020 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the library module."""

--- a/tests/lib/test_validator.py
+++ b/tests/lib/test_validator.py
@@ -1,0 +1,352 @@
+# Copyright 2020 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the validator library."""
+import logging
+import sys
+from unittest import TestCase
+from unittest.mock import patch, Mock
+from etos_api.lib.validator import SuiteValidator, ValidationError
+
+logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
+
+
+class TestValidator(TestCase):
+    """Test the validator library."""
+
+    logger = logging.getLogger(__name__)
+
+    @patch("etos_api.lib.validator.SuiteValidator._download_suite")
+    def test_validate_proper_suite(self, download_suite_mock):
+        """Test that the validator validates a proper suite correctly.
+
+        Approval criteria:
+            - Suite validator shall approve a proper suite.
+
+        Test steps::
+            1. Validate a proper suite.
+            2. Verify that no exceptions were raised.
+        """
+        download_suite_mock.return_value = {
+            "name": "TestValidator",
+            "priority": 1,
+            "recipes": [
+                {
+                    "constraints": [
+                        {"key": "ENVIRONMENT", "value": {}},
+                        {"key": "PARAMETERS", "value": {}},
+                        {"key": "COMMAND", "value": "exit 0"},
+                        {"key": "TEST_RUNNER", "value": "TestRunner"},
+                        {"key": "EXECUTE", "value": []},
+                        {"key": "CHECKOUT", "value": ["echo 'checkout'"]},
+                    ],
+                    "id": "131a7499-7ad4-4c4a-8a66-4e9ac95c7885",
+                    "testCase": {
+                        "id": "test_validate_proper_suite",
+                        "tracker": "Github",
+                        "url": "https://github.com/eiffel-community/etos-api",
+                    },
+                }
+            ],
+        }
+        self.logger.info("STEP: Validate a proper suite.")
+        validator = SuiteValidator(Mock())
+        try:
+            validator.validate()
+            exception = False
+        except (AssertionError, ValidationError):
+            exception = True
+        self.logger.info("STEP: Verify that no exceptions were raised.")
+        self.assertFalse(exception)
+
+    @patch("etos_api.lib.validator.SuiteValidator._download_suite")
+    def test_validate_missing_constraints(self, download_suite_mock):
+        """Test that the validator fails when missing required constraints.
+
+        Approval criteria:
+            - Suite validator shall not approve a suite with missing constraints.
+
+        Test steps::
+            1. Validate a suite with a missing constraint.
+            2. Verify that the validator raises ValidationError.
+        """
+        download_suite_mock.return_value = {
+            "name": "TestValidator",
+            "priority": 1,
+            "recipes": [
+                {
+                    "constraints": [
+                        {"key": "ENVIRONMENT", "value": {}},
+                        {"key": "PARAMETERS", "value": {}},
+                        {"key": "COMMAND", "value": "exit 0"},
+                        {"key": "EXECUTE", "value": []},
+                        {"key": "CHECKOUT", "value": ["echo 'checkout'"]},
+                    ],
+                    "id": "131a7499-7ad4-4c4a-8a66-4e9ac95c7887",
+                    "testCase": {
+                        "id": "test_validate_missing_constraints",
+                        "tracker": "Github",
+                        "url": "https://github.com/eiffel-community/etos-api",
+                    },
+                }
+            ],
+        }  # TEST_RUNNER is missing
+        self.logger.info("STEP: Validate a suite with a missing constraint.")
+        validator = SuiteValidator(Mock())
+        try:
+            validator.validate()
+            exception = False
+        except ValidationError:
+            exception = True
+        self.logger.info("STEP: Verify that the validator raises ValidationError.")
+        self.assertTrue(exception)
+
+    @patch("etos_api.lib.validator.SuiteValidator._download_suite")
+    def test_validate_wrong_types(self, download_suite_mock):
+        """Test that the validator fails when constraints have the wrong types.
+
+        Approval criteria:
+            - Suite validator shall not approve a suite wrong constraint types.
+
+        Test steps::
+            1. For each constraint.
+                1. Validate constraint with wrong type.
+                2. Verify that the validator raises ValidationError.
+        """
+        base_suite = {
+            "name": "TestValidator",
+            "priority": 1,
+            "recipes": [
+                {
+                    "constraints": [],  # Filled in loop
+                    "id": "131a7499-7ad4-4c4a-8a66-4e9ac95c7886",
+                    "testCase": {
+                        "id": "test_validate_wrong_types",
+                        "tracker": "Github",
+                        "url": "https://github.com/eiffel-community/etos-api",
+                    },
+                }
+            ],
+        }
+        constraints = [
+            [
+                {"key": "ENVIRONMENT", "value": "Wrong"},  # Wrong
+                {"key": "PARAMETERS", "value": {}},
+                {"key": "COMMAND", "value": "exit 0"},
+                {"key": "TEST_RUNNER", "value": "TestRunner"},
+                {"key": "EXECUTE", "value": []},
+                {"key": "CHECKOUT", "value": ["echo 'checkout'"]},
+            ],
+            [
+                {"key": "ENVIRONMENT", "value": {}},
+                {"key": "PARAMETERS", "value": "Wrong"},  # Wrong
+                {"key": "COMMAND", "value": "exit 0"},
+                {"key": "TEST_RUNNER", "value": "TestRunner"},
+                {"key": "EXECUTE", "value": []},
+                {"key": "CHECKOUT", "value": ["echo 'checkout'"]},
+            ],
+            [
+                {"key": "ENVIRONMENT", "value": {}},
+                {"key": "PARAMETERS", "value": {}},
+                {"key": "COMMAND", "value": {"wrong": True}},  # Wrong
+                {"key": "TEST_RUNNER", "value": "TestRunner"},
+                {"key": "EXECUTE", "value": []},
+                {"key": "CHECKOUT", "value": ["echo 'checkout'"]},
+            ],
+            [
+                {"key": "ENVIRONMENT", "value": {}},
+                {"key": "PARAMETERS", "value": {}},
+                {"key": "COMMAND", "value": "exit 0"},
+                {"key": "TEST_RUNNER", "value": {"wrong": True}},  # Wrong
+                {"key": "EXECUTE", "value": []},
+                {"key": "CHECKOUT", "value": ["echo 'checkout'"]},
+            ],
+            [
+                {"key": "ENVIRONMENT", "value": {}},
+                {"key": "PARAMETERS", "value": {}},
+                {"key": "COMMAND", "value": "exit 0"},
+                {"key": "TEST_RUNNER", "value": "TestRunner"},
+                {"key": "EXECUTE", "value": "Wrong"},  # Wrong
+                {"key": "CHECKOUT", "value": ["echo 'checkout'"]},
+            ],
+            [
+                {"key": "ENVIRONMENT", "value": {}},
+                {"key": "PARAMETERS", "value": {}},
+                {"key": "COMMAND", "value": "exit 0"},
+                {"key": "TEST_RUNNER", "value": "TestRunner"},
+                {"key": "EXECUTE", "value": []},
+                {"key": "CHECKOUT", "value": "Wrong"},  # Wrong
+            ],
+        ]
+        self.logger.info("STEP: For each constraint.")
+        validator = SuiteValidator(Mock())
+        for constraint in constraints:
+            self.logger.info("STEP: Validate constraint with wrong type.")
+            base_suite["recipes"][0]["constraints"] = constraint
+            download_suite_mock.return_value = base_suite
+            self.logger.info("STEP: Verify that the validator raises ValidationError.")
+            with self.assertRaises(ValidationError, msg=constraint):
+                validator.validate()
+
+    @patch("etos_api.lib.validator.SuiteValidator._download_suite")
+    def test_validate_too_many_constraints(self, download_suite_mock):
+        """Test that the validator fails when a constraint is defined multiple times.
+
+        Approval criteria:
+            - Suite validator shall not approve a suite with too many constraints.
+
+        Test steps::
+            1. Validate a suite with a constraint defined multiple times.
+            2. Verify that the validator raises ValidationError.
+        """
+        download_suite_mock.return_value = {
+            "name": "TestValidator",
+            "priority": 1,
+            "recipes": [
+                {
+                    "constraints": [
+                        {"key": "ENVIRONMENT", "value": {}},
+                        {"key": "PARAMETERS", "value": {}},
+                        {"key": "TEST_RUNNER", "value": "TestRunner"},
+                        {"key": "TEST_RUNNER", "value": "AnotherTestRunner"},
+                        {"key": "COMMAND", "value": "exit 0"},
+                        {"key": "EXECUTE", "value": []},
+                        {"key": "CHECKOUT", "value": ["echo 'checkout'"]},
+                    ],
+                    "id": "131a7499-7ad4-4c4a-8a66-4e9ac95c7887",
+                    "testCase": {
+                        "id": "test_validate_too_many_constraints",
+                        "tracker": "Github",
+                        "url": "https://github.com/eiffel-community/etos-api",
+                    },
+                }
+            ],
+        }
+        self.logger.info(
+            "STEP: Validate a suite with a constraint defined multiple times."
+        )
+        validator = SuiteValidator(Mock())
+        try:
+            validator.validate()
+            exception = False
+        except ValidationError:
+            exception = True
+        self.logger.info("STEP: Verify that the validator raises ValidationError.")
+        self.assertTrue(exception)
+
+    @patch("etos_api.lib.validator.SuiteValidator._download_suite")
+    def test_validate_unknown_constraint(self, download_suite_mock):
+        """Test that the validator fails when an unknown constraint is defined.
+
+        Approval criteria:
+            - Suite validator shall not approve a suite with an unknown constraint.
+
+        Test steps::
+            1. Validate a suite with an unknown constraint.
+            2. Verify that the validator raises ValidationError.
+        """
+        download_suite_mock.return_value = {
+            "name": "TestValidator",
+            "priority": 1,
+            "recipes": [
+                {
+                    "constraints": [
+                        {"key": "ENVIRONMENT", "value": {}},
+                        {"key": "PARAMETERS", "value": {}},
+                        {"key": "TEST_RUNNER", "value": "TestRunner"},
+                        {"key": "COMMAND", "value": "exit 0"},
+                        {"key": "EXECUTE", "value": []},
+                        {"key": "CHECKOUT", "value": ["echo 'checkout'"]},
+                        {"key": "UNKNOWN", "value": "Hello"},
+                    ],
+                    "id": "131a7499-7ad4-4c4a-8a66-4e9ac95c7887",
+                    "testCase": {
+                        "id": "test_validate_unknown_constraint",
+                        "tracker": "Github",
+                        "url": "https://github.com/eiffel-community/etos-api",
+                    },
+                }
+            ],
+        }
+        self.logger.info("STEP: Validate a suite with an unknown constraint.")
+        validator = SuiteValidator(Mock())
+        try:
+            validator.validate()
+            exception = False
+        except ValidationError:
+            exception = True
+        self.logger.info("STEP: Verify that the validator raises ValidationError.")
+        self.assertTrue(exception)
+
+    @patch("etos_api.lib.validator.SuiteValidator._download_suite")
+    def test_validate_empty_constraints(self, download_suite_mock):
+        """Test that required constraints are not empty.
+
+        Approval criteria:
+            - Constraints 'TEST_RUNNER', 'CHECKOUT' & 'COMMAND' shall not be empty.
+
+        Test steps::
+            1. For each required key.
+                1. Validate a suite without the required key.
+        """
+        base_suite = {
+            "name": "TestValidator",
+            "priority": 1,
+            "recipes": [
+                {
+                    "constraints": [],  # Filled below
+                    "id": "131a7499-7ad4-4c4a-8a66-4e9ac95c7892",
+                    "testCase": {
+                        "id": "test_validate_empty_constraints",
+                        "tracker": "Github",
+                        "url": "https://github.com/eiffel-community/etos-api",
+                    },
+                }
+            ],
+        }
+        constraints = [
+            [
+                {"key": "ENVIRONMENT", "value": {}},
+                {"key": "PARAMETERS", "value": {}},
+                {"key": "COMMAND", "value": ""},  # Empty
+                {"key": "TEST_RUNNER", "value": "TestRunner"},
+                {"key": "EXECUTE", "value": []},
+                {"key": "CHECKOUT", "value": ["echo 'checkout'"]},
+            ],
+            [
+                {"key": "ENVIRONMENT", "value": {}},
+                {"key": "PARAMETERS", "value": {}},
+                {"key": "COMMAND", "value": "exit 0"},
+                {"key": "TEST_RUNNER", "value": ""},  # Empty
+                {"key": "EXECUTE", "value": []},
+                {"key": "CHECKOUT", "value": ["echo 'checkout'"]},
+            ],
+            [
+                {"key": "ENVIRONMENT", "value": {}},
+                {"key": "PARAMETERS", "value": {}},
+                {"key": "COMMAND", "value": "exit 0"},
+                {"key": "TEST_RUNNER", "value": "TestRunner"},
+                {"key": "EXECUTE", "value": []},
+                {"key": "CHECKOUT", "value": []},  # Empty
+            ],
+        ]
+        self.logger.info("STEP: For each required key.")
+        validator = SuiteValidator(Mock())
+        for constraint in constraints:
+            base_suite["recipes"][0]["constraints"] = constraint
+            download_suite_mock.return_value = base_suite
+            self.logger.info("STEP: Validate a suite without the required key.")
+            with self.assertRaises(ValidationError, msg=constraint):
+                validator.validate()

--- a/tox.ini
+++ b/tox.ini
@@ -6,11 +6,11 @@
 [tox]
 envlist = py3,black,pylint,pydocstyle
 
-# [testenv]
-# deps =
-#     -r{toxinidir}/test-requirements.txt
-# commands =
-#     pytest -s --log-format="%(levelname)s: %(message)s" {posargs}
+[testenv]
+deps =
+    -r{toxinidir}/test-requirements.txt
+commands =
+    pytest -s --log-cli-level="DEBUG" --log-format="%(levelname)s: %(message)s" {posargs}
 
 [testenv:black]
 deps =


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
fixes: eiffel-community/etos#29

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Make use of pydantic models to do this validation.
Since we are going to move over to FastAPI and pydantic,
this is not a bad move.
Also added tests for this new library

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
We could opt out of pydantic and use jsonschema instead.
I decided to use pydantic because I see us using FastAPI and pydantic in the future to restructure this API.

### Benefits
<!-- What benefits will be realized by the change? -->
Fail faster

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
This validator must be updated whenever a change in the test definition is made.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
