### PR TITLE
Add logging support to ETOS API

### DIFF
--- a/src/etos_api/__init__.py
+++ b/src/etos_api/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Axis Communications AB.
+# Copyright 2020-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -14,3 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ETOS API module."""
+import os
+from importlib.metadata import version, PackageNotFoundError
+from etos_api.library.context_logging import ContextLogging
+from etos_lib.logging.logger import setup_logging
+
+try:
+    VERSION = version("environment_provider")
+except PackageNotFoundError:
+    VERSION = "Unknown"
+
+DEV = os.getenv("DEV", "false").lower() == "true"
+ENVIRONMENT = "development" if DEV else "production"
+setup_logging("ETOS API", VERSION, ENVIRONMENT)

--- a/src/etos_api/library/context_logging.py
+++ b/src/etos_api/library/context_logging.py
@@ -1,0 +1,78 @@
+# Copyright 2021 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ETOS API context based logging."""
+import logging
+from contextvars import ContextVar
+from etos_lib.logging.logger import setup_logging, FORMAT_CONFIG
+
+
+class ContextLogging(logging.Logger):
+    """A specialized context based logging class.
+
+    The ETOS API is based on asyncio and does not have
+    threaded contexts when running requests in parallel
+    and as such it cannot use the threading.local that is
+    used within FORMAT_CONFIG in the ETOS library.
+
+    This context based logging module replaces the FORMAT_CONFIG
+    with a ContextVar instead, which works with asyncio, and calls
+    get for each logging method called.
+    """
+
+    identifier = ContextVar("identifier")
+
+    def critical(self, msg, *args, **kwargs):
+        """Add identifier to critical calls.
+
+        For documentation read :obj:`logging.Logger.critical`
+        """
+        FORMAT_CONFIG.identifier = self.identifier.get("Main")  # Default=Main
+        return super().critical(msg, *args, **kwargs)
+
+    def error(self, msg, *args, **kwargs):
+        """Add identifier to error calls.
+
+        For documentation read :obj:`logging.Logger.error`
+        """
+        FORMAT_CONFIG.identifier = self.identifier.get("Main")  # Default=Main
+        return super().error(msg, *args, **kwargs)
+
+    def warning(self, msg, *args, **kwargs):
+        """Add identifier to warning calls.
+
+        For documentation read :obj:`logging.Logger.warning`
+        """
+        FORMAT_CONFIG.identifier = self.identifier.get("Main")  # Default=Main
+        return super().warning(msg, *args, **kwargs)
+
+    def info(self, msg, *args, **kwargs):
+        """Add identifier to info calls.
+
+        For documentation read :obj:`logging.Logger.info`
+        """
+        FORMAT_CONFIG.identifier = self.identifier.get("Main")  # Default=Main
+        return super().info(msg, *args, **kwargs)
+
+    def debug(self, msg, *args, **kwargs):
+        """Add identifier to debug calls.
+
+        For documentation read :obj:`logging.Logger.debug`
+        """
+        FORMAT_CONFIG.identifier = self.identifier.get("Main")  # Default=Main
+        return super().debug(msg, *args, **kwargs)
+
+
+logging.setLoggerClass(ContextLogging)

--- a/src/etos_api/main.py
+++ b/src/etos_api/main.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Axis Communications AB.
+# Copyright 2020-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -14,12 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ETOS API."""
+import logging
 from fastapi import FastAPI
 from starlette.responses import RedirectResponse
 from etos_api import routers
 
 
 APP = FastAPI()
+LOGGER = logging.getLogger(__name__)
 
 
 @APP.post("/")
@@ -29,6 +31,7 @@ async def redirect_post_to_root():
     :return: Redirect to etos.
     :rtype: :obj:`starlette.responses.RedirectResponse`
     """
+    LOGGER.debug("Redirecting post requests to the root endpoint to '/etos'")
     # DEPRECATED. Exists only for backwards compatibility.
     return RedirectResponse(url="/etos", status_code=308)  # 308 = Permanent Redirect
 
@@ -40,6 +43,7 @@ async def redirect_head_to_root():
     :return: Redirect to selftest/ping.
     :rtype: :obj:`starlette.responses.RedirectResponse`
     """
+    LOGGER.debug("Redirecting head requests to the root endpoint to '/sefltest/ping'")
     # DEPRECATED. Exists only for backwards compatibility.
     return RedirectResponse(
         url="/selftest/ping", status_code=308

--- a/src/etos_api/routers/selftest/router.py
+++ b/src/etos_api/routers/selftest/router.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Axis Communications AB.
+# Copyright 2020-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -14,10 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ETOS API selftest router."""
+import logging
 from starlette.responses import Response
 from fastapi import APIRouter
 
 ROUTER = APIRouter()
+LOGGER = logging.getLogger(__name__)
 
 
 @ROUTER.get("/selftest/ping", tags=["maintenance"], status_code=204)
@@ -33,4 +35,5 @@ async def ping():
 @ROUTER.head("/selftest/ping", tags=["maintenance"], status_code=204)
 async def head_ping():
     """Exists solely for backwards compatibility. DEPRECATED."""
+    LOGGER.warning("DEPRECATED HEAD request to ping received!")
     return Response(status_code=204)


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
eiffel-community/etos#70

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Add logging support to ETOS API as released in ETOS Library 1.8.0.
Added a new Logger class just for ETOS API as the ETOS API uses asyncio and it does not support the context based threading.local that is used in ETOS Library.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
The context based logging could be implemented into the ETOS Library logging module and be used by everyone. However I noted that it would be very difficult and might make the code in the ETOS Library a lot more complex than it needs to be.
If we start using asyncio more in the future, then this approach should be reconsidered.

### Benefits
<!-- What benefits will be realized by the change? -->
Better logging from the start of the ETOS chain.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None!

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
