### PR TITLE
Added ability to provide artifact ID instead of purl.

### DIFF
--- a/src/etos_api/library/graphql.py
+++ b/src/etos_api/library/graphql.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Axis Communications AB.
+# Copyright 2020-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -31,7 +31,7 @@ class GraphqlQueryHandler:  # pylint:disable=too-few-public-methods
         self.transport = AIOHTTPTransport(
             url=self.etos.debug.graphql_server,
             timeout=self.etos.debug.default_http_timeout,
-            client_session_args={"trust_env": True}
+            client_session_args={"trust_env": True},
         )
 
     async def execute(self, query):

--- a/src/etos_api/library/graphql_queries.py
+++ b/src/etos_api/library/graphql_queries.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Axis Communications AB.
+# Copyright 2020-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -15,11 +15,31 @@
 # limitations under the License.
 """Event repository queries."""
 
-ARTIFACT_QUERY = """
+ARTIFACT_IDENTITY_QUERY = """
 {
   artifactCreated(search: "{'data.identity': {'$regex': '%s'}}", last: 1) {
     edges {
       node {
+        data {
+          identity
+        }
+        meta {
+          id
+        }
+      }
+    }
+  }
+}
+"""
+
+VERIFY_ARTIFACT_ID_EXISTS = """
+{
+  artifactCreated(search: "{'meta.id': '%s'}", last: 1) {
+    edges {
+      node {
+        data {
+          identity
+        }
         meta {
           id
         }

--- a/src/etos_api/routers/etos/schemas.py
+++ b/src/etos_api/routers/etos/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Axis Communications AB.
+# Copyright 2020-2021 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -17,7 +17,7 @@
 import os
 from uuid import UUID
 from typing import Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
 # There's a bug with pylint detecting subscription on Optional objects as problematic.
 # https://github.com/PyCQA/pylint/issues/3882
@@ -27,7 +27,8 @@ from pydantic import BaseModel
 class StartEtosRequest(BaseModel):
     """Request model for the ETOS start API."""
 
-    artifact_identity: str
+    artifact_identity: Optional[str]
+    artifact_id: Optional[UUID]
     test_suite_url: str
     dataset: Optional[dict] = {}
     execution_space_provider: Optional[str] = os.getenv(
@@ -36,9 +37,24 @@ class StartEtosRequest(BaseModel):
     iut_provider: Optional[str] = os.getenv("DEFAULT_IUT_PROVIDER", "default")
     log_area_provider: Optional[str] = os.getenv("DEFAULT_LOG_AREA_PROVIDER", "default")
 
+    @validator("artifact_id", always=True)
+    def validate_id_or_identity(cls, v, values):
+        """Validate that at least one and only one of id and identity are set."""
+        if values.get("artifact_identity") is None and not v:
+            raise ValueError(
+                "At least one of 'artifact_identity' or 'artifact_id' is required."
+            )
+        if values.get("artifact_identity") is not None and v:
+            raise ValueError(
+                "Only one of 'artifact_identity' or 'artifact_id' is required."
+            )
+        return v
+
 
 class StartEtosResponse(BaseModel):
     """Response model for the ETOS start API."""
 
     event_repository: str
     tercc: UUID
+    artifact_id: UUID
+    artifact_identity: str

--- a/src/etos_api/routers/etos/schemas.py
+++ b/src/etos_api/routers/etos/schemas.py
@@ -38,17 +38,25 @@ class StartEtosRequest(BaseModel):
     log_area_provider: Optional[str] = os.getenv("DEFAULT_LOG_AREA_PROVIDER", "default")
 
     @validator("artifact_id", always=True)
-    def validate_id_or_identity(cls, v, values):
-        """Validate that at least one and only one of id and identity are set."""
-        if values.get("artifact_identity") is None and not v:
+    def validate_id_or_identity(cls, artifact_id, values):
+        """Validate that at least one and only one of id and identity are set.
+
+        :param artifact_id: The value of 'artifact_id' to validate.
+        :value artifact_id: str or None
+        :param values: The list of values set on the model.
+        :type values: list
+        :return: The value of artifact_id.
+        :rtype: str or None
+        """
+        if values.get("artifact_identity") is None and not artifact_id:
             raise ValueError(
                 "At least one of 'artifact_identity' or 'artifact_id' is required."
             )
-        if values.get("artifact_identity") is not None and v:
+        if values.get("artifact_identity") is not None and artifact_id:
             raise ValueError(
                 "Only one of 'artifact_identity' or 'artifact_id' is required."
             )
-        return v
+        return artifact_id
 
 
 class StartEtosResponse(BaseModel):

--- a/src/etos_api/routers/etos/utilities.py
+++ b/src/etos_api/routers/etos/utilities.py
@@ -18,18 +18,25 @@ import logging
 import asyncio
 import time
 from etos_api.library.graphql import GraphqlQueryHandler
-from etos_api.library.graphql_queries import ARTIFACT_QUERY
+from etos_api.library.graphql_queries import (
+    ARTIFACT_IDENTITY_QUERY,
+    VERIFY_ARTIFACT_ID_EXISTS,
+)
 
 LOGGER = logging.getLogger(__name__)
 
 
-async def wait_for_artifact_created(etos_library, artifact_identity, timeout=30):
+async def wait_for_artifact_created(
+    etos_library, artifact_identity, artifact_id, timeout=30
+):
     """Execute graphql query and wait for an artifact created.
 
     :param etos_library: ETOS library instande.
     :type etos_library: :obj:`etos_lib.etos.ETOS`
     :param artifact_identity: Identity of the artifact to get.
     :type artifact_identity: str
+    :param artifact_id: ID of the artifact to get.
+    :type artifact_id: UUID
     :param timeout: Maximum time to wait for a response (seconds).
     :type timeout: int
     :return: ArtifactCreated edges from GraphQL.
@@ -37,15 +44,23 @@ async def wait_for_artifact_created(etos_library, artifact_identity, timeout=30)
     """
     timeout = time.time() + timeout
     query_handler = GraphqlQueryHandler(etos_library)
+    if artifact_id is not None:
+        LOGGER.info("Verify that artifact ID %r exists.", artifact_id)
+        query = VERIFY_ARTIFACT_ID_EXISTS
+    else:
+        LOGGER.info("Getting artifact from packageURL %r", artifact_identity)
+        query = ARTIFACT_IDENTITY_QUERY
+    identity = artifact_identity or str(artifact_id)
+
     LOGGER.debug("Wait for artifact created event.")
     while time.time() < timeout:
         try:
-            artifact = await query_handler.execute(ARTIFACT_QUERY % artifact_identity)
+            artifact = await query_handler.execute(query % identity)
             assert artifact is not None
             assert artifact["artifactCreated"]["edges"]
             return artifact["artifactCreated"]["edges"]
         except (AssertionError, KeyError):
             LOGGER.warning("Artifact created not ready yet")
         await asyncio.sleep(2)
-    LOGGER.error("Artifact %r not found.", artifact_identity)
+    LOGGER.error("Artifact %r not found.", identity)
     return None


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
fixes: eiffel-community/etos#73

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Add the ability to start ETOS using artifact ID instead of PackageURL string for more explicit IUT selection.
Also ran black on all files.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
I opted to keep the packageurl imeplementation instead of removing as it would be a huge breaking change.

### Benefits
<!-- What benefits will be realized by the change? -->
We can start tests on a more explicit IUT, instead of relying on the package URL being unique.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None that I can think of.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
