### PR TITLE
Verify environment provider configuration before continuing

### DIFF
--- a/src/etos_api/routers/environment_provider/router.py
+++ b/src/etos_api/routers/environment_provider/router.py
@@ -28,6 +28,53 @@ ROUTER = APIRouter()
 LOGGER = logging.getLogger(__name__)
 
 
+async def _wait_for_configuration(etos_library, environment):
+    """Wait for the environment provider configuration to apply.
+
+    :param etos_library: An ETOS library instance for requesting the environment provider.
+    :type etos_library: :obj:`etos_lib.ETOS`
+    :param environment: Environment that has been configured.
+    :type environment: :obj:`etos_api.routers.etos.schemas.ConfigureEnvironmentProviderRequest`
+    """
+    LOGGER.info("Waiting for configuration to be applied in the environment provider.")
+    end_time = time.time() + etos_library.debug.default_http_timeout
+    LOGGER.debug("Timeout: %r", etos_library.debug.default_http_timeout)
+    async with aiohttp.ClientSession() as session:
+        while time.time() < end_time:
+            try:
+                async with session.get(
+                    f"{etos_library.debug.environment_provider}/configure",
+                    params={"suite_id": environment.suite_id},
+                    headers={
+                        "Content-Type": "application/json",
+                        "Accept": "application/json",
+                    },
+                ) as response:
+                    assert 200 <= response.status < 400
+                    response_json = await response.json()
+                    LOGGER.info("Configuration: %r", response_json)
+                    assert response_json.get("dataset") is not None
+                    assert response_json.get("iut_provider") is not None
+                    assert response_json.get("log_area_provider") is not None
+                    assert response_json.get("execution_space_provider") is not None
+                break
+            except AssertionError:
+                if response.status < 400:
+                    LOGGER.warning("Configuration not ready yet.")
+                else:
+                    LOGGER.warning(
+                        "Configuration verification request failed: %r, %r",
+                        response.status,
+                        response.reason,
+                    )
+                await asyncio.sleep(2)
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail="Environment provider configuration did not apply properly",
+            )
+
+
 @ROUTER.post(
     "/environment_provider/configure", tags=["environment_provider"], status_code=204
 )
@@ -70,3 +117,4 @@ async def configure_environment_provider(
                 status_code=400,
                 detail=f"Unable to configure environment provider with '{environment.json()}'",
             )
+        await _wait_for_configuration(etos_library, environment)


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
fixes: eiffel-community/etos#82

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Added a verification that a configuration has been applied to the environment provider before continuing on.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
This could be added to the environment provider configure endpoint instead and have it be verified every time, however I believe that the reduction of complexity on the environment provider API is better in this case.

### Benefits
<!-- What benefits will be realized by the change? -->
The API will verify the configuration before continuing on and, potentially, fail later.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
Another request to the environment provider.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
