### PR TITLE
Make regex query more efficient

### DIFF
--- a/src/etos_api/routers/etos/utilities.py
+++ b/src/etos_api/routers/etos/utilities.py
@@ -50,6 +50,9 @@ async def wait_for_artifact_created(
     elif artifact_identity is not None:
         LOGGER.info("Getting artifact from packageURL %r", artifact_identity)
         query = ARTIFACT_IDENTITY_QUERY
+        if artifact_identity.startswith("pkg:"):
+            # This makes the '$regex' query to the event repository more efficient.
+            artifact_identity = f"^{artifact_identity}"
     else:
         raise ValueError("'artifact_id' and 'artifact_identity' are both None!")
     artifact_identifier = artifact_identity or str(artifact_id)


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
fixes: eiffel-community/etos#104

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Added a "^" to the regex query for artifact identity in order to speed up the query.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
This design is pretty simple but it is unclear to the users. It is also quite dangerous that we allow all users to define the regex for searching for an identity and we might want to look into that.
Right now, however, this is a pretty simple and effective fix.

### Benefits
<!-- What benefits will be realized by the change? -->
Less strain on the event repository and, hopefully, some faster response time from ETOS API.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
Described a bit in "Alternate Designs" but this behavior is unclear to users.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
