### PR TITLE
Add selftest endpoint and an application layer

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -26,9 +26,9 @@ import (
 	"github.com/eiffel-community/etos-api/internal/config"
 	"github.com/eiffel-community/etos-api/internal/logging"
 	"github.com/eiffel-community/etos-api/internal/server"
+	"github.com/eiffel-community/etos-api/pkg/application"
+	"github.com/eiffel-community/etos-api/pkg/v1alpha1"
 	"github.com/sirupsen/logrus"
-
-	"github.com/julienschmidt/httprouter"
 )
 
 // GitSummary contains "git describe" output and is automatically
@@ -38,7 +38,6 @@ var GitSummary = "(unknown)"
 // main sets up logging and starts up the webserver.
 func main() {
 	cfg := config.Get()
-	handler := httprouter.New()
 	ctx := context.Background()
 
 	logger, err := logging.Setup(cfg)
@@ -55,6 +54,10 @@ func main() {
 		"application": "etos-api",
 		"version":     GitSummary,
 	})
+
+	log.Info("Loading v1alpha1 routes")
+	v1alpha1App := v1alpha1.New(cfg, log, ctx)
+	handler := application.New(v1alpha1App)
 
 	srv := server.NewWebserver(cfg, log, handler)
 

--- a/internal/responses/responses.go
+++ b/internal/responses/responses.go
@@ -1,0 +1,35 @@
+// Copyright 2021 Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package responses
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// RespondWithJSON writes a JSON response with a status code to the HTTP ResponseWriter.
+func RespondWithJSON(w http.ResponseWriter, code int, payload interface{}) {
+	response, _ := json.Marshal(payload)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_, _ = w.Write(response)
+}
+
+// RespondWithError writes a JSON response with an error message and status code to the HTTP ResponseWriter.
+func RespondWithError(w http.ResponseWriter, code int, message string) {
+	RespondWithJSON(w, code, map[string]string{"error": message})
+}

--- a/internal/responses/responses_test.go
+++ b/internal/responses/responses_test.go
@@ -1,0 +1,41 @@
+// Copyright 2021 Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package responses
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test that RespondWithJSON writes the correct HTTP code, message and adds a content type header.
+func TestRespondWithJSON(t *testing.T) {
+	responseRecorder := httptest.NewRecorder()
+	RespondWithJSON(responseRecorder, 200, map[string]string{"hello": "world"})
+	assert.Equal(t, "application/json", responseRecorder.Header().Get("Content-Type"))
+	assert.Equal(t, 200, responseRecorder.Result().StatusCode)
+	assert.JSONEq(t, `{"hello": "world"}`, responseRecorder.Body.String())
+}
+
+// Test that RespondWithError writes the correct HTTP code, message and adds a content type header.
+func TestRespondWithError(t *testing.T) {
+	responseRecorder := httptest.NewRecorder()
+	RespondWithError(responseRecorder, 400, "failure")
+	assert.Equal(t, "application/json", responseRecorder.Header().Get("Content-Type"))
+	assert.Equal(t, 400, responseRecorder.Result().StatusCode)
+	assert.JSONEq(t, `{"error": "failure"}`, responseRecorder.Body.String())
+}

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -1,0 +1,33 @@
+// Copyright 2021 Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package application
+
+import "github.com/julienschmidt/httprouter"
+
+type Application interface {
+	LoadRoutes(*httprouter.Router)
+}
+
+// New loads routes for all applications supplied and returns a new router to
+// be used in the server.
+func New(application Application, applications ...Application) *httprouter.Router {
+	router := httprouter.New()
+	application.LoadRoutes(router)
+	for _, app := range applications {
+		app.LoadRoutes(router)
+	}
+	return router
+}

--- a/pkg/application/application_test.go
+++ b/pkg/application/application_test.go
@@ -1,0 +1,77 @@
+// Copyright 2021 Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package application
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/stretchr/testify/assert"
+)
+
+type testApp struct {
+	route   string
+	message string
+}
+
+func (t *testApp) testRoute(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	fmt.Fprint(w, t.message)
+}
+
+func (t *testApp) LoadRoutes(router *httprouter.Router) {
+	router.GET(t.route, t.testRoute)
+}
+
+// TestNew verifies that it is possible to load a handlers routes.
+func TestNew(t *testing.T) {
+	app := &testApp{
+		route:   "/testing",
+		message: "hello",
+	}
+	router := New(app)
+
+	responseRecorder := httptest.NewRecorder()
+	request := httptest.NewRequest("GET", app.route, nil)
+	router.ServeHTTP(responseRecorder, request)
+	assert.Equal(t, 200, responseRecorder.Code)
+	assert.Equal(t, app.message, responseRecorder.Body.String())
+}
+
+// TestNew verifies that it is possible to load multiple handlers routes.
+func TestNewMultiple(t *testing.T) {
+	route1 := &testApp{"/route1", "hello1"}
+	route2 := &testApp{"/route2", "hello2"}
+	tests := []struct {
+		name string
+		app  *testApp
+	}{
+		{name: "Route1", app: route1},
+		{name: "Route1", app: route2},
+	}
+
+	router := New(route1, route2)
+
+	for _, testCase := range tests {
+		responseRecorder := httptest.NewRecorder()
+		request := httptest.NewRequest("GET", testCase.app.route, nil)
+		router.ServeHTTP(responseRecorder, request)
+		assert.Equal(t, 200, responseRecorder.Code)
+		assert.Equal(t, testCase.app.message, responseRecorder.Body.String())
+	}
+}

--- a/pkg/v1alpha1/v1alpha1.go
+++ b/pkg/v1alpha1/v1alpha1.go
@@ -1,0 +1,55 @@
+// Copyright 2021 Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package v1alpha1
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/eiffel-community/etos-api/internal/config"
+	"github.com/eiffel-community/etos-api/internal/responses"
+	"github.com/eiffel-community/etos-api/pkg/application"
+	"github.com/julienschmidt/httprouter"
+	"github.com/sirupsen/logrus"
+)
+
+type V1Alpha1Application struct {
+	logger *logrus.Entry
+	cfg    config.Config
+}
+
+type V1Alpha1Handler struct {
+	logger *logrus.Entry
+	cfg    config.Config
+}
+
+func New(cfg config.Config, log *logrus.Entry, ctx context.Context) application.Application {
+	return &V1Alpha1Application{
+		logger: log,
+		cfg:    cfg,
+	}
+}
+
+// LoadRoutes loads all the v1alpha1 routes.
+func (a *V1Alpha1Application) LoadRoutes(router *httprouter.Router) {
+	handler := &V1Alpha1Handler{a.logger, a.cfg}
+	router.GET("/v1alpha1/selftest/ping", handler.Selftest)
+}
+
+// Selftest is a handler to just return 204.
+func (h *V1Alpha1Handler) Selftest(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	responses.RespondWithError(w, http.StatusNoContent, "")
+}

--- a/pkg/v1alpha1/v1alpha1_test.go
+++ b/pkg/v1alpha1/v1alpha1_test.go
@@ -1,0 +1,59 @@
+// Copyright 2021 Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package v1alpha1
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/eiffel-community/etos-api/pkg/application"
+	"github.com/eiffel-community/etos-api/test/testconfig"
+	"github.com/julienschmidt/httprouter"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNew verifies that New creates an Application interface.
+func TestNew(t *testing.T) {
+	ctx := context.Background()
+	log := &logrus.Entry{}
+	cfg := testconfig.Get("", "", "", "")
+	v1alpha1 := New(cfg, log, ctx)
+	assert.Implements(t, (*application.Application)(nil), v1alpha1)
+}
+
+// TestLoadRoutes verifies that it is possible to load the v1alpha1 routes.
+func TestLoadRoutes(t *testing.T) {
+	router := httprouter.New()
+	v1alpha1 := &V1Alpha1Application{}
+	v1alpha1.LoadRoutes(router)
+
+	responseRecorder := httptest.NewRecorder()
+	request := httptest.NewRequest("GET", "/v1alpha1/selftest/ping", nil)
+	router.ServeHTTP(responseRecorder, request)
+	assert.Equal(t, 204, responseRecorder.Code)
+}
+
+// TestSelftest verifies that the selftest endpoint returns 204 No Content.
+func TestSelftest(t *testing.T) {
+	router := application.New(&V1Alpha1Application{})
+
+	responseRecorder := httptest.NewRecorder()
+	request := httptest.NewRequest("GET", "/v1alpha1/selftest/ping", nil)
+	router.ServeHTTP(responseRecorder, request)
+	assert.Equal(t, 204, responseRecorder.Code)
+}


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
eiffel-community/etos#116

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
added the selftest/ping endpoint, some response handling and an application layer.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
One design that I chose not to do here is the one where I have an application that starts the webserver, an API for each version and handlers separated in different packages.
In this design I chose to have the application and server separate and loading in routes to the application which is then used in the server. This means that we have a simpler code-base but it is not as flexible.
My hope is that this simplicity is worth it. (Example of the other style: https://github.com/eiffel-community/eiffel-goer)

### Benefits
<!-- What benefits will be realized by the change? -->
Implementation of the first required endpoint.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
