### PR TITLE
Add environment provider configuration to StartETOS endpoint

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,17 +30,19 @@ type Config interface {
 	LogLevel() string
 	LogFilePath() string
 	EventRepositoryHost() string
+	EnvironmentProviderHost() string
 	Timeout() time.Duration
 }
 
 // cfg implements the Config interface.
 type cfg struct {
-	apiHost             string
-	apiPort             string
-	logLevel            string
-	logFilePath         string
-	eventRepositoryHost string
-	timeout             time.Duration
+	apiHost                 string
+	apiPort                 string
+	logLevel                string
+	logFilePath             string
+	eventRepositoryHost     string
+	environmentProviderHost string
+	timeout                 time.Duration
 }
 
 // Get creates a config interface based on input parameters or environment variables.
@@ -57,6 +59,7 @@ func Get() Config {
 	flag.StringVar(&conf.logLevel, "loglevel", EnvOrDefault("LOGLEVEL", "INFO"), "Log level (TRACE, DEBUG, INFO, WARNING, ERROR, FATAL, PANIC).")
 	flag.StringVar(&conf.logFilePath, "logfilepath", os.Getenv("LOG_FILE_PATH"), "Path, including filename, for the log files to create.")
 	flag.StringVar(&conf.eventRepositoryHost, "eventrepository", os.Getenv("ETOS_GRAPHQL_SERVER"), "Host to the GraphQL server to use for event lookup.")
+	flag.StringVar(&conf.environmentProviderHost, "environmentprovider", os.Getenv("ETOS_ENVIRONMENT_PROVIDER"), "Host to the ETOS environment provider.")
 	flag.DurationVar(&conf.timeout, "timeout", defaultTimeout, "Maximum timeout for requests to ETOS API.")
 
 	flag.Parse()
@@ -81,6 +84,11 @@ func (c *cfg) LogFilePath() string {
 // EventRepositoryHost returns the host to use for event lookups.
 func (c *cfg) EventRepositoryHost() string {
 	return c.eventRepositoryHost
+}
+
+// EnvironmentProvider returns the host to use for configuring the environment provider.
+func (c *cfg) EnvironmentProviderHost() string {
+	return c.environmentProviderHost
 }
 
 // Timeout returns the request timeout for starting ETOS.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,12 +30,14 @@ func TestGet(t *testing.T) {
 	logLevel := "DEBUG"
 	logFilePath := "path/to/a/file"
 	erHost := "http://er/graphql"
+	epHost := "http://environment-provider"
 	timeoutStr := "1m"
 	os.Setenv("SERVER_HOST", serverHost)
 	os.Setenv("API_PORT", port)
 	os.Setenv("LOGLEVEL", logLevel)
 	os.Setenv("LOG_FILE_PATH", logFilePath)
 	os.Setenv("ETOS_GRAPHQL_SERVER", erHost)
+	os.Setenv("ETOS_ENVIRONMENT_PROVIDER", epHost)
 	os.Setenv("REQUEST_TIMEOUT", timeoutStr)
 
 	timeout, _ := time.ParseDuration(timeoutStr)
@@ -47,6 +49,7 @@ func TestGet(t *testing.T) {
 	assert.Equal(t, logLevel, conf.logLevel)
 	assert.Equal(t, logFilePath, conf.logFilePath)
 	assert.Equal(t, erHost, conf.eventRepositoryHost)
+	assert.Equal(t, epHost, conf.environmentProviderHost)
 	assert.Equal(t, timeout, conf.timeout)
 }
 
@@ -55,11 +58,12 @@ type getter func() string
 // Test that the getters in the Cfg struct return the values from the struct.
 func TestGetters(t *testing.T) {
 	conf := &cfg{
-		apiHost:             "127.0.0.1",
-		apiPort:             "8080",
-		logLevel:            "TRACE",
-		logFilePath:         "a/file/path.json",
-		eventRepositoryHost: "http://er/graphql",
+		apiHost:                 "127.0.0.1",
+		apiPort:                 "8080",
+		logLevel:                "TRACE",
+		logFilePath:             "a/file/path.json",
+		eventRepositoryHost:     "http://er/graphql",
+		environmentProviderHost: "http://environment-provider",
 	}
 	tests := []struct {
 		name     string
@@ -71,6 +75,7 @@ func TestGetters(t *testing.T) {
 		{name: "LogLevel", cfg: conf, function: conf.LogLevel, value: conf.logLevel},
 		{name: "LogFilePath", cfg: conf, function: conf.LogFilePath, value: conf.logFilePath},
 		{name: "EventRepositoryHost", cfg: conf, function: conf.EventRepositoryHost, value: conf.eventRepositoryHost},
+		{name: "EnvironmentProviderHost", cfg: conf, function: conf.EnvironmentProviderHost, value: conf.environmentProviderHost},
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -26,7 +26,7 @@ import (
 
 // TestLoggingSetup tests that it is possible to setup logging without a filehook.
 func TestLoggingSetup(t *testing.T) {
-	cfg := testconfig.Get("127.0.0.1", "8080", "INFO", "", "", "1m")
+	cfg := testconfig.Get("127.0.0.1", "8080", "INFO", "", "", "", "1m")
 	log, err := Setup(cfg)
 	assert.Nil(t, err)
 	assert.Nil(t, log.Hooks[logrus.InfoLevel])
@@ -34,7 +34,7 @@ func TestLoggingSetup(t *testing.T) {
 
 // TestLoggingSetupFileHook tests that it is possible to setup logging with a filehook.
 func TestLoggingSetupFileHook(t *testing.T) {
-	cfg := testconfig.Get("127.0.0.1", "8080", "INFO", "testdata/logs.json", "", "1m")
+	cfg := testconfig.Get("127.0.0.1", "8080", "INFO", "testdata/logs.json", "", "", "1m")
 	log, err := Setup(cfg)
 	assert.Nil(t, err)
 	assert.NotNil(t, log.Hooks[logrus.InfoLevel])
@@ -42,7 +42,7 @@ func TestLoggingSetupFileHook(t *testing.T) {
 
 // TestLoggingSetupBadLogLevel shall return an error if loglevel is not parseable.
 func TestLoggingSetupBadLogLevel(t *testing.T) {
-	cfg := testconfig.Get("127.0.0.1", "8080", "NOTALOGLEVEL", "", "", "1m")
+	cfg := testconfig.Get("127.0.0.1", "8080", "NOTALOGLEVEL", "", "", "", "1m")
 	_, err := Setup(cfg)
 	assert.Error(t, err)
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -28,7 +28,7 @@ import (
 // implements the Server interface
 func TestNewWebserver(t *testing.T) {
 	log := &logrus.Entry{}
-	cfg := testconfig.Get("", "", "", "", "", "1m")
+	cfg := testconfig.Get("", "", "", "", "", "", "1m")
 	webserver := NewWebserver(cfg, log, http.Handler(nil))
 	assert.Implements(t, (*Server)(nil), webserver)
 }

--- a/pkg/v1alpha1/environmentprovider.go
+++ b/pkg/v1alpha1/environmentprovider.go
@@ -1,0 +1,205 @@
+// Copyright 2021 Axis Communications AB.
+//
+// For a full list of individual contributors, please see the commit history.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package v1alpha1
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/sethvargo/go-retry"
+	"github.com/sirupsen/logrus"
+)
+
+type EnvironmentProvider struct {
+	host   string
+	logger *logrus.Entry
+}
+
+func NewEnvironmentProvider(logger *logrus.Entry, host string) *EnvironmentProvider {
+	return &EnvironmentProvider{
+		host:   host,
+		logger: logger,
+	}
+}
+
+type EnvironmentProviderConfiguration struct {
+	SuiteID                string                 `json:"suite_id"`
+	Dataset                map[string]interface{} `json:"dataset"`
+	ExecutionSpaceProvider string                 `json:"execution_space_provider"`
+	IUTProvider            string                 `json:"iut_provider"`
+	LogAreaProvider        string                 `json:"log_area_provider"`
+}
+
+type EnvironmentProviderResponse struct {
+	Dataset                map[string]interface{} `json:"dataset"`
+	ExecutionSpaceProvider map[string]interface{} `json:"execution_space_provider"`
+	IUTProvider            map[string]interface{} `json:"iut_provider"`
+	LogAreaProvider        map[string]interface{} `json:"log_area_provider"`
+}
+
+func (e *EnvironmentProvider) Configure(ctx context.Context, configuration EnvironmentProviderConfiguration) error {
+	e.logger.Infof("configuring environment provider (%s) with suite ID %s", e.host, configuration.SuiteID)
+	host := strings.Join([]string{e.host, "configure"}, "/")
+	client := http.Client{}
+	body, err := json.Marshal(configuration)
+	if err != nil {
+		return err
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, host, bytes.NewBuffer(body))
+	if err != nil {
+		e.logger.Errorf("building http request failed: %v", err)
+		return err
+	}
+	request.Header.Add("Accept", "application/json")
+	request.Header.Add("Content-Type", "application/json")
+
+	response, err := client.Do(request)
+	if err != nil {
+		e.logger.Errorf("http request failed: %v", err)
+		return err
+	}
+	if response.Body != nil {
+		defer response.Body.Close()
+	}
+	if response.StatusCode != http.StatusOK {
+		return NewHTTPError(fmt.Errorf("error when configuring environment (%s)", response.Status), response.StatusCode)
+	}
+	e.logger.Info(host)
+	e.logger.Info("environment provider configured")
+	return nil
+}
+
+func (e *EnvironmentProvider) Verify(ctx context.Context, configuration EnvironmentProviderConfiguration) error {
+	e.logger.Infof("verify environment provider configuration with suite ID %s", configuration.SuiteID)
+	host := strings.Join([]string{e.host, "configure"}, "/")
+	client := http.Client{}
+	e.logger.Debugf("starting a GET request to %s", host)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, host, nil)
+	if err != nil {
+		e.logger.Errorf("building http request failed: %v", err)
+		return err
+	}
+	request.Header.Add("Accept", "application/json")
+	request.Header.Add("Content-Type", "application/json")
+	q := request.URL.Query()
+	q.Add("suite_id", configuration.SuiteID)
+	request.URL.RawQuery = q.Encode()
+	response, err := client.Do(request)
+	if err != nil {
+		e.logger.Errorf("http request failed: %v", err)
+		return err
+	}
+	if response.Body != nil {
+		defer response.Body.Close()
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return NewHTTPError(fmt.Errorf("failed to verify the test suite due to HTTP errors (%s)", response.Status), response.StatusCode)
+	}
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		e.logger.Errorf("failed to read http response: %v", err)
+		return err
+	}
+	var configuredEnvironment EnvironmentProviderResponse
+	err = json.Unmarshal(body, &configuredEnvironment)
+	if err != nil {
+		e.logger.Error(err)
+		return errors.New("failed to parse environment provider configuration as JSON")
+	}
+	if configuredEnvironment.ExecutionSpaceProvider["id"] != configuration.ExecutionSpaceProvider {
+		return errors.New("execution space provider is not configured properly")
+	} else if configuredEnvironment.IUTProvider["id"] != configuration.IUTProvider {
+		return errors.New("IUT provider is not configured properly")
+	} else if configuredEnvironment.LogAreaProvider["id"] != configuration.LogAreaProvider {
+		return errors.New("log area provider is not configured properly")
+	}
+	e.logger.Info("environment provider configuration verified")
+	return nil
+}
+
+// configureEnvironmentProvider configures the environment provider with the input data from
+// the user starting ETOS.
+func configureEnvironmentProvider(ctx context.Context, logger *logrus.Entry, environmentProvider *EnvironmentProvider, configuration EnvironmentProviderConfiguration) error {
+	err := retry.Fibonacci(ctx, 1*time.Second, func(ctx context.Context) error {
+		err := environmentProvider.Configure(ctx, configuration)
+		if err == nil {
+			return nil
+		}
+		switch httpError := err.(type) {
+		case *HTTPError:
+			// Cannot recover from client errors making it unnecessary to retry.
+			if httpError.Code >= 400 && httpError.Code < 500 {
+				return err
+			}
+			return retry.RetryableError(err)
+		default:
+			return retry.RetryableError(err)
+		}
+	})
+	if err != nil {
+		logger.Errorf("failed configuring environment provider: %+v", err)
+		// Yes, it's correct with double '&' in these two statements.
+		// This is because 'As panics if target is not a non-nil pointer to
+		// either a type that implements error, or to any interface type'.
+		errType := &HTTPError{}
+		if errors.As(err, &errType) {
+			return err
+		}
+		return NewHTTPError(err, http.StatusRequestTimeout)
+	}
+	return nil
+}
+
+// verifyEnvironmentProvider verifies that the environment provider configuration is set correctly.
+func verifyEnvironmentProvider(ctx context.Context, logger *logrus.Entry, environmentProvider *EnvironmentProvider, configuration EnvironmentProviderConfiguration) error {
+	err := retry.Fibonacci(ctx, 1*time.Second, func(ctx context.Context) error {
+		err := environmentProvider.Verify(ctx, configuration)
+		if err == nil {
+			return nil
+		}
+		switch httpError := err.(type) {
+		case *HTTPError:
+			// Cannot recover from client errors making it unnecessary to retry.
+			if httpError.Code >= 400 && httpError.Code < 500 {
+				return err
+			}
+			return retry.RetryableError(err)
+		default:
+			return retry.RetryableError(err)
+		}
+	})
+	if err != nil {
+		logger.Errorf("failed verifying environment provider configuration: %+v", err)
+		// Yes, it's correct with double '&' in these two statements.
+		// This is because 'As panics if target is not a non-nil pointer to
+		// either a type that implements error, or to any interface type'.
+		errType := &HTTPError{}
+		if errors.As(err, &errType) {
+			return err
+		}
+		return NewHTTPError(err, http.StatusRequestTimeout)
+	}
+	return nil
+}

--- a/pkg/v1alpha1/environmentprovider.go
+++ b/pkg/v1alpha1/environmentprovider.go
@@ -35,6 +35,7 @@ type EnvironmentProvider struct {
 	logger *logrus.Entry
 }
 
+// NewEnvironmentProvider creates a new environment provider struct with host an logger.
 func NewEnvironmentProvider(logger *logrus.Entry, host string) *EnvironmentProvider {
 	return &EnvironmentProvider{
 		host:   host,
@@ -57,16 +58,17 @@ type EnvironmentProviderResponse struct {
 	LogAreaProvider        map[string]interface{} `json:"log_area_provider"`
 }
 
+// Configure posts a configuration to the ETOS environment provider.
 func (e *EnvironmentProvider) Configure(ctx context.Context, configuration EnvironmentProviderConfiguration) error {
 	e.logger.Infof("configuring environment provider (%s) with suite ID %s", e.host, configuration.SuiteID)
-	host := strings.Join([]string{e.host, "configure"}, "/")
+	url := strings.Join([]string{e.host, "configure"}, "/")
 	client := http.Client{}
 	body, err := json.Marshal(configuration)
 	if err != nil {
 		return err
 	}
 
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, host, bytes.NewBuffer(body))
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(body))
 	if err != nil {
 		e.logger.Errorf("building http request failed: %v", err)
 		return err
@@ -85,17 +87,18 @@ func (e *EnvironmentProvider) Configure(ctx context.Context, configuration Envir
 	if response.StatusCode != http.StatusOK {
 		return NewHTTPError(fmt.Errorf("error when configuring environment (%s)", response.Status), response.StatusCode)
 	}
-	e.logger.Info(host)
+	e.logger.Info(url)
 	e.logger.Info("environment provider configured")
 	return nil
 }
 
+// Verify will request the environment provider to verify that the configuration has been properly added.
 func (e *EnvironmentProvider) Verify(ctx context.Context, configuration EnvironmentProviderConfiguration) error {
 	e.logger.Infof("verify environment provider configuration with suite ID %s", configuration.SuiteID)
-	host := strings.Join([]string{e.host, "configure"}, "/")
+	url := strings.Join([]string{e.host, "configure"}, "/")
 	client := http.Client{}
-	e.logger.Debugf("starting a GET request to %s", host)
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, host, nil)
+	e.logger.Debugf("starting a GET request to %s", url)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		e.logger.Errorf("building http request failed: %v", err)
 		return err

--- a/pkg/v1alpha1/v1alpha1.go
+++ b/pkg/v1alpha1/v1alpha1.go
@@ -103,6 +103,24 @@ func (h *V1Alpha1Handler) StartETOS(w http.ResponseWriter, r *http.Request, ps h
 		sendError(w, err)
 		return
 	}
+	configuration := EnvironmentProviderConfiguration{
+		SuiteID:                identifier,
+		Dataset:                request.Dataset,
+		ExecutionSpaceProvider: request.ExecutionSpaceProvider,
+		IUTProvider:            request.IUTProvider,
+		LogAreaProvider:        request.LogAreaProvider,
+	}
+	environmentProvider := NewEnvironmentProvider(logger, h.cfg.EnvironmentProviderHost())
+	if err := configureEnvironmentProvider(ctx, logger, environmentProvider, configuration); err != nil {
+		logger.Error(err.Error())
+		sendError(w, err)
+		return
+	}
+	if err := verifyEnvironmentProvider(ctx, logger, environmentProvider, configuration); err != nil {
+		logger.Error(err.Error())
+		sendError(w, err)
+		return
+	}
 
 	response = StartResponse{
 		EventRepository:  h.cfg.EventRepositoryHost(),

--- a/pkg/v1alpha1/v1alpha1_test.go
+++ b/pkg/v1alpha1/v1alpha1_test.go
@@ -31,7 +31,7 @@ import (
 func TestNew(t *testing.T) {
 	ctx := context.Background()
 	log := &logrus.Entry{}
-	cfg := testconfig.Get("", "", "", "", "", "1m")
+	cfg := testconfig.Get("", "", "", "", "", "", "1m")
 	v1alpha1 := New(cfg, log, ctx)
 	assert.Implements(t, (*application.Application)(nil), v1alpha1)
 }

--- a/test/testconfig/testconfig.go
+++ b/test/testconfig/testconfig.go
@@ -24,26 +24,28 @@ import (
 )
 
 type cfg struct {
-	apiHost             string
-	apiPort             string
-	logLevel            string
-	logFilePath         string
-	eventRepositoryHost string
-	timeout             time.Duration
+	apiHost                 string
+	apiPort                 string
+	logLevel                string
+	logFilePath             string
+	eventRepositoryHost     string
+	environmentProviderHost string
+	timeout                 time.Duration
 }
 
-func Get(apiHost, apiPort, logLevel, logFilePath, erHost, timeoutStr string) config.Config {
+func Get(apiHost, apiPort, logLevel, logFilePath, erHost, epHost, timeoutStr string) config.Config {
 	timeout, err := time.ParseDuration(timeoutStr)
 	if err != nil {
 		logrus.Panic("timeout could not be parsed")
 	}
 	return &cfg{
-		apiHost:             apiHost,
-		apiPort:             apiPort,
-		logLevel:            logLevel,
-		logFilePath:         logFilePath,
-		eventRepositoryHost: erHost,
-		timeout:             timeout,
+		apiHost:                 apiHost,
+		apiPort:                 apiPort,
+		logLevel:                logLevel,
+		logFilePath:             logFilePath,
+		eventRepositoryHost:     erHost,
+		environmentProviderHost: epHost,
+		timeout:                 timeout,
 	}
 }
 
@@ -60,6 +62,10 @@ func (c *cfg) LogFilePath() string {
 }
 
 func (c *cfg) EventRepositoryHost() string {
+	return c.eventRepositoryHost
+}
+
+func (c *cfg) EnvironmentProviderHost() string {
 	return c.eventRepositoryHost
 }
 


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
eiffel-community/etos#116

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
StartAPI will now configure and verify the configuration of environment provider.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
None

### Benefits
<!-- What benefits will be realized by the change? -->
This is a feature in the old implementation and is, as such, required.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None at all!

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
