### PR TITLE
Make sure that the ETOS publisher is properly closed

### DIFF
--- a/src/etos_api/routers/etos/router.py
+++ b/src/etos_api/routers/etos/router.py
@@ -110,10 +110,15 @@ async def start_etos(etos: StartEtosRequest):
 
     LOGGER.info("Start event publisher.")
     await sync_to_async(etos_library.start_publisher)
+    await sync_to_async(etos_library.publisher.wait_start)
     LOGGER.info("Event published started successfully.")
     LOGGER.info("Publish TERCC event.")
-    async with aclosing(etos_library.publisher):
+    try:
         event = etos_library.events.send(tercc, links, data)
+        await sync_to_async(etos_library.publisher.wait_for_unpublished_events)
+    finally:
+        await sync_to_async(etos_library.publisher.stop)
+        await sync_to_async(etos_library.publisher.wait_close)
     LOGGER.info("Event published.")
 
     LOGGER.info("ETOS triggered successfully.")


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
With the update to Eiffellib there is a lot more output from items running in threads and it spammed the logs a lot.
Probably because the connection is not properly shut down.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
The aclosing helper could have been updated to do 'stop' instead. But I don't know what else that would affect.

### Benefits
<!-- What benefits will be realized by the change? -->
The connection closes and the logs are cleaner

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
