### PR TITLE
Validate test runner

### DIFF
--- a/src/etos_api/library/docker.py
+++ b/src/etos_api/library/docker.py
@@ -115,7 +115,7 @@ class Docker:
         return base, tag
 
     def repository(self, repo: str) -> tuple[str, str]:
-        """Figure out repository and repo from a container image name.
+        """Figure out repository and registry from a container image name.
 
         :param repo: Name of image, including or excluding registry URL.
         :return: Registry URL and the repo path for that registry.

--- a/src/etos_api/library/docker.py
+++ b/src/etos_api/library/docker.py
@@ -38,7 +38,7 @@ class Docker:
     tokens = {}
     lock = Lock()
 
-    def token(self, manifest_url):
+    def token(self, manifest_url: str) -> str:
         """Get a stored token, removing it if expired.
 
         :param manifest_url: URL the token has been stored for.
@@ -105,6 +105,12 @@ class Docker:
         tag = ""
 
         parts = base.split(TAG_DELIMITER)
+        # Verify that we aren't confusing a tag for a hostname w/ port
+        # If there are more than one ':' in the image name, we'll assume
+        # that the container tag is after the second ':', not the first.
+        # By checking if the first part (i.e. hostname w/ port) does not
+        # have any '/', we will also catch cases where there's a
+        # hostname w/ port and no tag in the image name.
         if len(parts) > 1 and REPO_DELIMITER not in parts[-1]:
             base = TAG_DELIMITER.join(parts[:-1])
             tag = parts[-1]
@@ -138,7 +144,7 @@ class Docker:
             registry = DEFAULT_REGISTRY
         return registry, repo
 
-    async def digest(self, name):
+    async def digest(self, name: str) -> str:
         """Get a sha256 digest from an image in an image repository.
 
         :param name: The name of the container image.

--- a/src/etos_api/library/docker.py
+++ b/src/etos_api/library/docker.py
@@ -1,0 +1,175 @@
+# Copyright 2023 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Docker operations for the ETOS API."""
+import time
+import logging
+from threading import Lock
+import aiohttp
+
+DEFAULT_TAG = "latest"
+DEFAULT_REGISTRY = "index.docker.io"
+REPO_DELIMITER = "/"
+TAG_DELIMITER = ":"
+
+
+class Docker:
+    """Docker handler for HTTP operations against docker registries.
+
+    This handler is heavily inspired by `crane digest`:
+    https://github.com/google/go-containerregistry/tree/main/cmd/crane
+    """
+
+    logger = logging.getLogger(__name__)
+    # In-memory database for stored authorization tokens.
+    # This dictionary shares memory with all instances of `Docker`, by design.
+    tokens = {}
+    lock = Lock()
+
+    def token(self, manifest_url):
+        """Get a stored token, removing it if expired.
+
+        :param manifest_url: URL the token has been stored for.
+        :return: A token or None.
+        """
+        with self.lock:
+            token = self.tokens.get(manifest_url, {})
+            if token:
+                if time.time() >= token["expire"]:
+                    self.logger.info("Registry token expired for %r", manifest_url)
+                    self.tokens.pop(manifest_url)
+                    token = {}
+            return token.get("token")
+
+    async def head(
+        self, session: aiohttp.ClientSession, url: str, token: str = None
+    ) -> aiohttp.ClientResponse:
+        """Make a HEAD request to a URL, adding token to headers if supplied.
+
+        :param session: Client HTTP session to use for HTTP request.
+        :param url: URL to make HEAD request to.
+        :param token: Optional authorization token.
+        :return: HTTP response.
+        """
+        headers = {}
+        if token is not None:
+            headers["Authorization"] = f"Bearer {token}"
+
+        async with session.head(url, headers=headers) as response:
+            return response
+
+    async def authorize(
+        self, session: aiohttp.ClientSession, response: aiohttp.ClientResponse
+    ) -> str:
+        """Get a token from an unauthorized request to image repository.
+
+        :param session: Client HTTP session to use for HTTP request.
+        :param response: HTTP response to get headers from.
+        :return: Response JSON from authorization request.
+        """
+        header = response.headers.get("www-authenticate")
+        header = header.replace("Bearer ", "")
+        parts = header.split(",")
+
+        url = None
+        query = {}
+        for part in parts:
+            key, value = part.split("=")
+            if key == "realm":
+                url = value.strip('"')
+            else:
+                query[key] = value.strip('"')
+
+        async with session.get(url, params=query) as response:
+            response.raise_for_status()
+            return await response.json()
+
+    def tag(self, base: str) -> tuple[str, str]:
+        """Figure out tag from a container image name.
+
+        :param base: Name of image.
+        :return: Base image name without tag and tag name.
+        """
+        tag = ""
+
+        parts = base.split(TAG_DELIMITER)
+        if len(parts) > 1 and REPO_DELIMITER not in parts[-1]:
+            base = TAG_DELIMITER.join(parts[:-1])
+            tag = parts[-1]
+            self.logger.info("Assuming tag is %r", tag)
+        if tag == "":
+            tag = DEFAULT_TAG
+            self.logger.info("Assuming default tag %r", tag)
+        return base, tag
+
+    def repository(self, repo: str) -> tuple[str, str]:
+        """Figure out repository and repo from a container image name.
+
+        :param repo: Name of image, including or excluding registry URL.
+        :return: Registry URL and the repo path for that registry.
+        """
+        registry = ""
+        parts = repo.split(REPO_DELIMITER, 1)
+        if len(parts) == 2 and ("." in parts[0] or ":" in parts[0]):
+            # The first part of the repository is treated as the registry domain
+            # if it contains a '.' or ':' character, otherwise it is all repository
+            # and the domain defaults to Docker Hub.
+            registry = parts[0]
+            repo = parts[1]
+            self.logger.info(
+                "Probably found a registry URL in image name: (registry=%r, repo=%r)",
+                registry,
+                repo,
+            )
+        if registry in ("", "docker.io"):
+            self.logger.info("Assuming registry is %r for %r", DEFAULT_REGISTRY, repo)
+            registry = DEFAULT_REGISTRY
+        return registry, repo
+
+    async def digest(self, name):
+        """Get a sha256 digest from an image in an image repository.
+
+        :param name: The name of the container image.
+        :return: The sha256 digest of the container image.
+        """
+        self.logger.info("Figure out digest for %r", name)
+        base, tag = self.tag(name)
+        registry, repo = self.repository(base)
+        manifest_url = f"https://{registry}/v2/{repo}/manifests/{tag}"
+
+        digest = None
+        async with aiohttp.ClientSession() as session:
+            self.logger.info("Get digest from %r", manifest_url)
+            response = await self.head(session, manifest_url, self.token(manifest_url))
+            try:
+                if response.status == 401 and "www-authenticate" in response.headers:
+                    self.logger.info(
+                        "Generate a new authorization token for %r", manifest_url
+                    )
+                    response_json = await self.authorize(session, response)
+                    with self.lock:
+                        self.tokens[manifest_url] = {
+                            "token": response_json.get("token"),
+                            "expire": time.time() + response_json.get("expires_in"),
+                        }
+                    response = await self.head(
+                        session, manifest_url, self.token(manifest_url)
+                    )
+                digest = response.headers.get("Docker-Content-Digest")
+            except aiohttp.ClientResponseError as exception:
+                self.logger.error("Error getting container image %r", exception)
+                digest = None
+        self.logger.info("Returning digest %r from %r", digest, manifest_url)
+        return digest


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
fixes: eiffel-community/etos#156
This change derives from #38 and that commit can be ignored in this PR.

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Verify that we can receive a digest via the docker repository APIs.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
I wanted to use the docker cli tool to do this but was not able to get it to work without doing `docker pull`, which we definitely don't want to do.

### Benefits
<!-- What benefits will be realized by the change? -->
Tests will fail faster when the test runner does not exist leaving the users with less confusion.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
HTTP requests are, relatively, costly and something we have to do on every single run of ETOS. We might have to do some caching of the data if this becomes to heavy.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
