### PR TITLE
Enable opentelemetry support in the ETOS API

### DIFF
--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -14,9 +14,7 @@ import sys
 import inspect
 import shutil
 
-__location__ = os.path.join(
-    os.getcwd(), os.path.dirname(inspect.getfile(inspect.currentframe()))
-)
+__location__ = os.path.join(os.getcwd(), os.path.dirname(inspect.getfile(inspect.currentframe())))
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -21,3 +21,7 @@ gql[requests]~=3.4
 httpx~=0.24
 kubernetes~=26.1
 sse-starlette~=1.6
+opentelemetry-api~=1.21
+opentelemetry-exporter-otlp~=1.21
+opentelemetry-instrumentation-fastapi==0.42b0
+opentelemetry-sdk~=1.21

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -33,6 +33,10 @@ install_requires =
     httpx~=0.24
     kubernetes~=26.1
     sse-starlette~=1.6
+    opentelemetry-api~=1.21
+    opentelemetry-exporter-otlp~=1.21
+    opentelemetry-instrumentation-fastapi==0.42b0
+    opentelemetry-sdk~=1.21
 
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = >=3.4

--- a/python/src/etos_api/__init__.py
+++ b/python/src/etos_api/__init__.py
@@ -15,19 +15,44 @@
 # limitations under the License.
 """ETOS API module."""
 import os
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
+
 from etos_lib.logging.logger import setup_logging
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.sdk.resources import SERVICE_NAME, SERVICE_NAMESPACE, SERVICE_VERSION, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
 from etos_api.library.context_logging import ContextLogging
+
+from .main import APP
 
 # The API shall not send logs to RabbitMQ as it
 # is too early in the ETOS test run.
 os.environ["ETOS_ENABLE_SENDING_LOGS"] = "false"
 
 try:
-    VERSION = version("environment_provider")
+    VERSION = version("etos_api")
 except PackageNotFoundError:
     VERSION = "Unknown"
 
 DEV = os.getenv("DEV", "false").lower() == "true"
 ENVIRONMENT = "development" if DEV else "production"
 setup_logging("ETOS API", VERSION, ENVIRONMENT)
+
+if os.getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"):
+    PROVIDER = TracerProvider(
+        resource=Resource.create(
+            {SERVICE_NAME: "etos-api", SERVICE_VERSION: VERSION, SERVICE_NAMESPACE: ENVIRONMENT}
+        )
+    )
+    EXPORTER = OTLPSpanExporter()
+    PROCESSOR = BatchSpanProcessor(EXPORTER)
+    PROVIDER.add_span_processor(PROCESSOR)
+    trace.set_tracer_provider(PROVIDER)
+
+    FastAPIInstrumentor().instrument_app(
+        APP, tracer_provider=PROVIDER, excluded_urls="selftest/.*,logs/.*"
+    )

--- a/python/src/etos_api/library/docker.py
+++ b/python/src/etos_api/library/docker.py
@@ -161,18 +161,14 @@ class Docker:
             response = await self.head(session, manifest_url, self.token(manifest_url))
             try:
                 if response.status == 401 and "www-authenticate" in response.headers:
-                    self.logger.info(
-                        "Generate a new authorization token for %r", manifest_url
-                    )
+                    self.logger.info("Generate a new authorization token for %r", manifest_url)
                     response_json = await self.authorize(session, response)
                     with self.lock:
                         self.tokens[manifest_url] = {
                             "token": response_json.get("token"),
                             "expire": time.time() + response_json.get("expires_in"),
                         }
-                    response = await self.head(
-                        session, manifest_url, self.token(manifest_url)
-                    )
+                    response = await self.head(session, manifest_url, self.token(manifest_url))
                 digest = response.headers.get("Docker-Content-Digest")
             except aiohttp.ClientResponseError as exception:
                 self.logger.error("Error getting container image %r", exception)

--- a/python/src/etos_api/library/utilities.py
+++ b/python/src/etos_api/library/utilities.py
@@ -62,9 +62,7 @@ async def sync_to_async(function, *args, **kwargs):
     loop = asyncio.get_event_loop()
     future = loop.run_in_executor(
         None,  # Default executor.
-        functools.partial(
-            thread_exception_handler, sys.exc_info(), function, *args, **kwargs
-        ),
+        functools.partial(thread_exception_handler, sys.exc_info(), function, *args, **kwargs),
     )
     return await asyncio.wait_for(future, timeout=None)
 

--- a/python/src/etos_api/library/validator.py
+++ b/python/src/etos_api/library/validator.py
@@ -101,9 +101,7 @@ class Recipe(BaseModel):
     }
 
     @validator("constraints")
-    def validate_constraints(
-        cls, value
-    ):  # Pydantic requires cls. pylint:disable=no-self-argument
+    def validate_constraints(cls, value):  # Pydantic requires cls. pylint:disable=no-self-argument
         """Validate the constraints fields for each recipe.
 
         Validation is done manually because error messages from pydantic
@@ -133,14 +131,10 @@ class Recipe(BaseModel):
             count[constraint.key] += 1
         more_than_one = [key for key, number in count.items() if number > 1]
         if more_than_one:
-            raise ValueError(
-                f"Too many instances of keys {more_than_one}. Only 1 allowed."
-            )
+            raise ValueError(f"Too many instances of keys {more_than_one}. Only 1 allowed.")
         missing = [key for key, number in count.items() if number == 0]
         if missing:
-            raise ValueError(
-                f"Too few instances of keys {missing}. At least 1 required."
-            )
+            raise ValueError(f"Too few instances of keys {missing}. At least 1 required.")
         return value
 
 
@@ -169,9 +163,7 @@ class SuiteValidator:
             suite = requests.get(test_suite_url, timeout=60)
             suite.raise_for_status()
         except Exception as exception:  # pylint:disable=broad-except
-            raise AssertionError(
-                f"Unable to download suite from {test_suite_url}"
-            ) from exception
+            raise AssertionError(f"Unable to download suite from {test_suite_url}") from exception
         return suite.json()
 
     async def validate(self, test_suite_url):

--- a/python/src/etos_api/main.py
+++ b/python/src/etos_api/main.py
@@ -15,10 +15,13 @@
 # limitations under the License.
 """ETOS API."""
 import logging
-from fastapi import FastAPI
-from starlette.responses import RedirectResponse
-from etos_api import routers
 
+from fastapi import FastAPI
+
+# from opentelemetry.sdk.trace import TracerProvider
+from starlette.responses import RedirectResponse
+
+from etos_api import routers
 
 APP = FastAPI()
 LOGGER = logging.getLogger(__name__)
@@ -45,9 +48,7 @@ async def redirect_head_to_root():
     """
     LOGGER.debug("Redirecting head requests to the root endpoint to '/sefltest/ping'")
     # DEPRECATED. Exists only for backwards compatibility.
-    return RedirectResponse(
-        url="/selftest/ping", status_code=308
-    )  # 308 = Permanent Redirect
+    return RedirectResponse(url="/selftest/ping", status_code=308)  # 308 = Permanent Redirect
 
 
 APP.include_router(routers.etos.ROUTER)

--- a/python/src/etos_api/routers/environment_provider/router.py
+++ b/python/src/etos_api/routers/environment_provider/router.py
@@ -14,17 +14,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Environment provider proxy API."""
-import logging
 import asyncio
+import logging
 import os
 import time
+
 import aiohttp
-from fastapi import APIRouter, HTTPException
 from etos_lib import ETOS
+from fastapi import APIRouter, HTTPException
+from opentelemetry import trace
 
 from .schemas import ConfigureEnvironmentProviderRequest
 
 ROUTER = APIRouter()
+TRACER = trace.get_tracer("etos_api.routers.environment_provider.router")
 LOGGER = logging.getLogger(__name__)
 
 
@@ -36,48 +39,48 @@ async def _wait_for_configuration(etos_library, environment):
     :param environment: Environment that has been configured.
     :type environment: :obj:`etos_api.routers.etos.schemas.ConfigureEnvironmentProviderRequest`
     """
-    LOGGER.info("Waiting for configuration to be applied in the environment provider.")
-    end_time = time.time() + etos_library.debug.default_http_timeout
-    LOGGER.debug("Timeout: %r", etos_library.debug.default_http_timeout)
-    async with aiohttp.ClientSession() as session:
-        while time.time() < end_time:
-            try:
-                async with session.get(
-                    f"{etos_library.debug.environment_provider}/configure",
-                    params={"suite_id": environment.suite_id},
-                    headers={
-                        "Content-Type": "application/json",
-                        "Accept": "application/json",
-                    },
-                ) as response:
-                    assert 200 <= response.status < 400
-                    response_json = await response.json()
-                    LOGGER.info("Configuration: %r", response_json)
-                    assert response_json.get("dataset") is not None
-                    assert response_json.get("iut_provider") is not None
-                    assert response_json.get("log_area_provider") is not None
-                    assert response_json.get("execution_space_provider") is not None
-                break
-            except AssertionError:
-                if response.status < 400:
-                    LOGGER.warning("Configuration not ready yet.")
-                else:
-                    LOGGER.warning(
-                        "Configuration verification request failed: %r, %r",
-                        response.status,
-                        response.reason,
-                    )
-                await asyncio.sleep(2)
-        else:
-            raise HTTPException(
-                status_code=400,
-                detail="Environment provider configuration did not apply properly",
-            )
+    with TRACER.start_as_current_span("wait-for-configuration") as span:
+        LOGGER.info("Waiting for configuration to be applied in the environment provider.")
+        end_time = time.time() + etos_library.debug.default_http_timeout
+        LOGGER.debug("Timeout: %r", etos_library.debug.default_http_timeout)
+        span.set_attribute("timeout", etos_library.debug.default_http_timeout)
+        async with aiohttp.ClientSession() as session:
+            while time.time() < end_time:
+                try:
+                    async with session.get(
+                        f"{etos_library.debug.environment_provider}/configure",
+                        params={"suite_id": environment.suite_id},
+                        headers={
+                            "Content-Type": "application/json",
+                            "Accept": "application/json",
+                        },
+                    ) as response:
+                        assert 200 <= response.status < 400
+                        response_json = await response.json()
+                        LOGGER.info("Configuration: %r", response_json)
+                        assert response_json.get("dataset") is not None
+                        assert response_json.get("iut_provider") is not None
+                        assert response_json.get("log_area_provider") is not None
+                        assert response_json.get("execution_space_provider") is not None
+                    break
+                except AssertionError:
+                    if response.status < 400:
+                        LOGGER.warning("Configuration not ready yet.")
+                    else:
+                        LOGGER.warning(
+                            "Configuration verification request failed: %r, %r",
+                            response.status,
+                            response.reason,
+                        )
+                    await asyncio.sleep(2)
+            else:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Environment provider configuration did not apply properly",
+                )
 
 
-@ROUTER.post(
-    "/environment_provider/configure", tags=["environment_provider"], status_code=204
-)
+@ROUTER.post("/environment_provider/configure", tags=["environment_provider"], status_code=204)
 async def configure_environment_provider(
     environment: ConfigureEnvironmentProviderRequest,
 ):
@@ -86,35 +89,42 @@ async def configure_environment_provider(
     :param environment: Environment to configure.
     :type environment: :obj:`etos_api.routers.etos.schemas.ConfigureEnvironmentProviderRequest`
     """
-    LOGGER.identifier.set(environment.suite_id)
-    LOGGER.info("Configuring environment provider using %r", environment)
-    etos_library = ETOS("ETOS API", os.getenv("HOSTNAME"), "ETOS API")
+    with TRACER.start_as_current_span("configure-environment-provider") as span:
+        LOGGER.identifier.set(environment.suite_id)
+        span.set_attribute("etos.id", environment.suite_id)
+        span.set_attribute("etos.iut_provider", environment.iut_provider)
+        span.set_attribute("etos.execution_space_provider", environment.execution_space_provider)
+        span.set_attribute("etos.log_area_provider", environment.log_area_provider)
+        span.set_attribute("etos.dataset", str(environment.dataset))
 
-    end_time = time.time() + etos_library.debug.default_http_timeout
-    LOGGER.debug("HTTP Timeout: %r", etos_library.debug.default_http_timeout)
-    async with aiohttp.ClientSession() as session:
-        while time.time() < end_time:
-            try:
-                async with session.post(
-                    f"{etos_library.debug.environment_provider}/configure",
-                    json=environment.dict(),
-                    headers={
-                        "Content-Type": "application/json",
-                        "Accept": "application/json",
-                    },
-                ) as response:
-                    assert 200 <= response.status < 400
-                break
-            except AssertionError:
-                LOGGER.warning(
-                    "Configuration request failed: %r, %r",
-                    response.status,
-                    response.reason,
+        LOGGER.info("Configuring environment provider using %r", environment)
+        etos_library = ETOS("ETOS API", os.getenv("HOSTNAME"), "ETOS API")
+
+        end_time = time.time() + etos_library.debug.default_http_timeout
+        LOGGER.debug("HTTP Timeout: %r", etos_library.debug.default_http_timeout)
+        async with aiohttp.ClientSession() as session:
+            while time.time() < end_time:
+                try:
+                    async with session.post(
+                        f"{etos_library.debug.environment_provider}/configure",
+                        json=environment.dict(),
+                        headers={
+                            "Content-Type": "application/json",
+                            "Accept": "application/json",
+                        },
+                    ) as response:
+                        assert 200 <= response.status < 400
+                    break
+                except AssertionError:
+                    LOGGER.warning(
+                        "Configuration request failed: %r, %r",
+                        response.status,
+                        response.reason,
+                    )
+                    await asyncio.sleep(2)
+            else:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Unable to configure environment provider with '{environment.json()}'",
                 )
-                await asyncio.sleep(2)
-        else:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Unable to configure environment provider with '{environment.json()}'",
-            )
-        await _wait_for_configuration(etos_library, environment)
+            await _wait_for_configuration(etos_library, environment)

--- a/python/src/etos_api/routers/etos/router.py
+++ b/python/src/etos_api/routers/etos/router.py
@@ -15,55 +15,62 @@
 # limitations under the License.
 """ETOS API router."""
 import logging
-from uuid import uuid4
 import os
-from fastapi import APIRouter, HTTPException
-from etos_lib import ETOS
-from eiffellib.events import EiffelTestExecutionRecipeCollectionCreatedEvent
+from uuid import uuid4
 
-from etos_api.library.validator import SuiteValidator
+from eiffellib.events import EiffelTestExecutionRecipeCollectionCreatedEvent
+from etos_lib import ETOS
+from fastapi import APIRouter, HTTPException
+from opentelemetry import trace
+
 from etos_api.library.utilities import sync_to_async
+from etos_api.library.validator import SuiteValidator
 from etos_api.routers.environment_provider.router import configure_environment_provider
-from etos_api.routers.environment_provider.schemas import (
-    ConfigureEnvironmentProviderRequest,
-)
+from etos_api.routers.environment_provider.schemas import ConfigureEnvironmentProviderRequest
+
 from .schemas import StartEtosRequest, StartEtosResponse
 from .utilities import wait_for_artifact_created
 
 ROUTER = APIRouter()
+TRACER = trace.get_tracer("etos_api.routers.etos.router")
 LOGGER = logging.getLogger(__name__)
 logging.getLogger("pika").setLevel(logging.WARNING)
 
 
-@ROUTER.post("/etos", tags=["etos"], response_model=StartEtosResponse)
-async def start_etos(etos: StartEtosRequest):
-    """Start ETOS execution on post.
+async def validate_suite(test_suite_url: str) -> None:
+    """Validate the ETOS test suite through the SuiteValidator.
 
-    :param etos: ETOS pydantic model.
-    :type etos: :obj:`etos_api.routers.etos.schemas.StartEtosRequest`
-    :return: JSON dictionary with response.
-    :rtype: dict
+    :param test_suite_url: The URL to the test suite to validate.
     """
-    tercc = EiffelTestExecutionRecipeCollectionCreatedEvent()
-    LOGGER.identifier.set(tercc.meta.event_id)
-
-    LOGGER.info("Validating test suite.")
     try:
-        await SuiteValidator().validate(etos.test_suite_url)
+        await SuiteValidator().validate(test_suite_url)
     except AssertionError as exception:
         LOGGER.error("Test suite validation failed!")
         LOGGER.error(exception)
         raise HTTPException(
             status_code=400, detail=f"Test suite validation failed. {exception}"
         ) from exception
+
+
+async def _start(etos: StartEtosRequest, span: "Span") -> dict:
+    """Start ETOS execution.
+
+    :param etos: ETOS pydantic model.
+    :param span: An opentelemetry span for tracing.
+    :return: JSON dictionary with response.
+    """
+    tercc = EiffelTestExecutionRecipeCollectionCreatedEvent()
+    LOGGER.identifier.set(tercc.meta.event_id)
+    span.set_attribute("etos.id", tercc.meta.event_id)
+
+    LOGGER.info("Validating test suite.")
+    await validate_suite(etos.test_suite_url)
     LOGGER.info("Test suite validated.")
 
     etos_library = ETOS("ETOS API", os.getenv("HOSTNAME"), "ETOS API")
     await sync_to_async(etos_library.config.rabbitmq_publisher_from_environment)
 
-    LOGGER.info(
-        "Get artifact created %r", (etos.artifact_identity or str(etos.artifact_id))
-    )
+    LOGGER.info("Get artifact created %r", (etos.artifact_identity or str(etos.artifact_id)))
     try:
         artifact = await wait_for_artifact_created(
             etos_library, etos.artifact_identity, etos.artifact_id
@@ -86,6 +93,8 @@ async def start_etos(etos: StartEtosRequest):
     # Same goes for 'data'.'identity'.
     artifact_id = artifact[0]["node"]["meta"]["id"]
     identity = artifact[0]["node"]["data"]["identity"]
+    span.set_attribute("etos.artifact.id", artifact_id)
+    span.set_attribute("etos.artifact.identity", identity)
 
     links = {"CAUSE": artifact_id}
     data = {
@@ -131,3 +140,16 @@ async def start_etos(etos: StartEtosRequest):
         "artifact_identity": identity,
         "event_repository": etos_library.debug.graphql_server,
     }
+
+
+@ROUTER.post("/etos", tags=["etos"], response_model=StartEtosResponse)
+async def start_etos(etos: StartEtosRequest):
+    """Start ETOS execution on post.
+
+    :param etos: ETOS pydantic model.
+    :type etos: :obj:`etos_api.routers.etos.schemas.StartEtosRequest`
+    :return: JSON dictionary with response.
+    :rtype: dict
+    """
+    with TRACER.start_as_current_span("start-etos") as span:
+        return await _start(etos, span)

--- a/python/src/etos_api/routers/etos/schemas.py
+++ b/python/src/etos_api/routers/etos/schemas.py
@@ -50,13 +50,9 @@ class StartEtosRequest(BaseModel):
         :rtype: str or None
         """
         if values.get("artifact_identity") is None and not artifact_id:
-            raise ValueError(
-                "At least one of 'artifact_identity' or 'artifact_id' is required."
-            )
+            raise ValueError("At least one of 'artifact_identity' or 'artifact_id' is required.")
         if values.get("artifact_identity") is not None and artifact_id:
-            raise ValueError(
-                "Only one of 'artifact_identity' or 'artifact_id' is required."
-            )
+            raise ValueError("Only one of 'artifact_identity' or 'artifact_id' is required.")
         return artifact_id
 
 

--- a/python/src/etos_api/routers/etos/utilities.py
+++ b/python/src/etos_api/routers/etos/utilities.py
@@ -26,9 +26,7 @@ from etos_api.library.graphql_queries import (
 LOGGER = logging.getLogger(__name__)
 
 
-async def wait_for_artifact_created(
-    etos_library, artifact_identity, artifact_id, timeout=30
-):
+async def wait_for_artifact_created(etos_library, artifact_identity, artifact_id, timeout=30):
     """Execute graphql query and wait for an artifact created.
 
     :param etos_library: ETOS library instande.

--- a/python/src/etos_api/routers/logs/router.py
+++ b/python/src/etos_api/routers/logs/router.py
@@ -14,16 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ETOS API log handler."""
-import os
 import asyncio
 import logging
+import os
 from uuid import UUID
-from kubernetes import client, config
-from fastapi import APIRouter, HTTPException
 
+import httpx
+from fastapi import APIRouter, HTTPException
+from kubernetes import client, config
 from sse_starlette.sse import EventSourceResponse
 from starlette.requests import Request
-import httpx
 
 NAMESPACE_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 LOGGER = logging.getLogger(__name__)
@@ -65,9 +65,7 @@ async def get_logs(uuid: UUID, request: Request):
         ):
             ip_addr = pod.status.pod_ip
     if ip_addr is None:
-        raise HTTPException(
-            status_code=404, detail=f"Suite runner with UUID={uuid} not found"
-        )
+        raise HTTPException(status_code=404, detail=f"Suite runner with UUID={uuid} not found")
 
     async def sse(url):
         index = 0

--- a/python/tests/library/test_validator.py
+++ b/python/tests/library/test_validator.py
@@ -246,9 +246,7 @@ class TestValidator:
                 ],
             }
         ]
-        self.logger.info(
-            "STEP: Validate a suite with a constraint defined multiple times."
-        )
+        self.logger.info("STEP: Validate a suite with a constraint defined multiple times.")
         validator = SuiteValidator()
         try:
             await validator.validate("url")

--- a/python/tests/test_routers.py
+++ b/python/tests/test_routers.py
@@ -169,9 +169,7 @@ class TestRouters:
     @patch("etos_api.library.validator.SuiteValidator._download_suite")
     @patch("etos_api.library.graphql.GraphqlQueryHandler.execute")
     @patch("etos_api.routers.environment_provider.router.aiohttp.ClientSession")
-    def test_start_etos(
-        self, mock_client, graphql_execute_mock, download_suite_mock, digest_mock
-    ):
+    def test_start_etos(self, mock_client, graphql_execute_mock, download_suite_mock, digest_mock):
         """Test that POST requests to /etos attempts to start ETOS tests.
 
         Approval criteria:
@@ -313,9 +311,7 @@ class TestRouters:
         self.logger.info("STEP: Verify that the status code is 204.")
         assert response.status_code == 204
 
-        self.logger.info(
-            "STEP: Verify that the request was sent to the environment provider."
-        )
+        self.logger.info("STEP: Verify that the request was sent to the environment provider.")
         debug = Debug()
         mock_client.post.assert_called_once_with(
             f"{debug.environment_provider}/configure",

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -21,7 +21,7 @@ commands =
 deps =
     black
 commands =
-    black --check --diff .
+    black --check --diff -l 100 .
 
 [testenv:pylint]
 deps =


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
eiffel-community/etos#204

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Added optional support for open telemetry.
I also ran black -l 100 and I had to change a few things in the start_etos endpoint where it had too many statements (pylint).

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
Opentelemetry was used because it is the biggest and most popular tracing framework. I also decided to only support OTLP since that's what I'm going to be using, if any other exporters become required they can be added.

### Benefits
<!-- What benefits will be realized by the change? -->
This allows us to detect problems with the ETOS API.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
I did not concern myself with traces that span multiple microservices. That is a bigger beast to tackle.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
