### PR TITLE
Use Python 3.9 base image instead of 3.9.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.9.0-buster AS build
+FROM python:3.9-buster AS build
 
 COPY . /src
 WORKDIR /src/python
 RUN python3 setup.py bdist_wheel
 
-FROM python:3.9.0-slim-buster
+FROM python:3.9-slim-buster
 ARG TZ
 ENV TZ=$TZ
 

--- a/deploy/etos-sse/Dockerfile
+++ b/deploy/etos-sse/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.20-alpine AS build
 WORKDIR /tmp/sse
 COPY . .
-RUN apk add --no-cache make=4.4.1-r1 git=2.40.1-r0 && make build
+RUN apk add --no-cache make=4.4.1-r2 git=2.43.0-r0 && make build
 
 FROM alpine:3.17.3
 ARG TZ
@@ -11,7 +11,7 @@ LABEL org.opencontainers.image.source=https://github.com/eiffel-community/etos-a
 LABEL org.opencontainers.image.authors=etos-maintainers@googlegroups.com
 LABEL org.opencontainers.image.licenses=Apache-2.0
 
-RUN apk add --no-cache tzdata=2023c-r0
+RUN apk add --no-cache tzdata=2024a-r0
 ENTRYPOINT ["/app/etos-sse"]
 
 COPY --from=build /tmp/sse/bin/etos-sse /app/etos-sse

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     sse-starlette~=1.6
     opentelemetry-api~=1.21
     opentelemetry-exporter-otlp~=1.21
-    opentelemetry-instrumentation-fastapi==0.42b0
+    opentelemetry-instrumentation-fastapi==0.43b0
     opentelemetry-sdk~=1.21
 
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4


### PR DESCRIPTION
### Applicable Issues

- [ETOS Docker API build fails with 3.9.0 base image](https://github.com/eiffel-community/etos/issues/207)

### Description of the Change
- The change changes the base image to the latest 3.9 base, without locking to a specific minor version.

### Alternate Designs

### Possible Drawbacks

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andreimu@axis.com