### PR TITLE
Abort running suites using DELETE request

### DIFF
--- a/manifests/base/role.yaml
+++ b/manifests/base/role.yaml
@@ -9,11 +9,21 @@ metadata:
     rbac.authorization.kubernetes.io/autoupdate: "true"
   name: etos-api:sa:pod-reader
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
+   # apiGroups batch shall be defined before apiGroups ""
+  - apiGroups:
+    - "batch"
+    resources:
+    - jobs
+    verbs:
+    - get
+    - delete
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - get
+    - list
+    - watch

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -24,5 +24,5 @@ kubernetes~=26.1
 sse-starlette~=1.6
 opentelemetry-api~=1.21
 opentelemetry-exporter-otlp~=1.21
-opentelemetry-instrumentation-fastapi==0.43b0
+opentelemetry-instrumentation-fastapi==0.44b0
 opentelemetry-sdk~=1.21

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     sse-starlette~=1.6
     opentelemetry-api~=1.21
     opentelemetry-exporter-otlp~=1.21
-    opentelemetry-instrumentation-fastapi==0.43b0
+    opentelemetry-instrumentation-fastapi==0.44b0
     opentelemetry-sdk~=1.21
 
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4

--- a/python/src/etos_api/routers/etos/schemas.py
+++ b/python/src/etos_api/routers/etos/schemas.py
@@ -25,8 +25,16 @@ from pydantic import BaseModel, Field, field_validator  # pylint:disable=no-name
 # pylint: disable=no-self-argument
 
 
-class StartEtosRequest(BaseModel):
-    """Request model for the ETOS start API."""
+class EtosRequest(BaseModel):
+    """Base class for ETOS request models."""
+
+
+class EtosResponse(BaseModel):
+    """Base class for ETOS response models."""
+
+
+class StartEtosRequest(EtosRequest):
+    """Request model for the start endpoint of the ETOS API."""
 
     artifact_identity: Optional[str]
     artifact_id: Optional[UUID] = Field(default=None, validate_default=True)
@@ -57,10 +65,16 @@ class StartEtosRequest(BaseModel):
         return artifact_id
 
 
-class StartEtosResponse(BaseModel):
-    """Response model for the ETOS start API."""
+class StartEtosResponse(EtosResponse):
+    """Response model for the start endpoint of the ETOS API."""
 
     event_repository: str
     tercc: UUID
     artifact_id: UUID
     artifact_identity: str
+
+
+class AbortEtosResponse(EtosResponse):
+    """Response model for the abort endpoint of the ETOS API."""
+
+    message: str

--- a/python/src/etos_api/routers/lib/__init__.py
+++ b/python/src/etos_api/routers/lib/__init__.py
@@ -1,0 +1,16 @@
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Generic helpers for all submodules."""

--- a/python/src/etos_api/routers/lib/kubernetes.py
+++ b/python/src/etos_api/routers/lib/kubernetes.py
@@ -1,0 +1,46 @@
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Generic Kubernetes helpers for all submodules."""
+import logging
+import os
+
+from kubernetes import config
+
+NAMESPACE_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+LOGGER = logging.getLogger(__name__)
+
+try:
+    config.load_incluster_config()
+except config.ConfigException:
+    try:
+        config.load_config()
+    except config.ConfigException:
+        LOGGER.warning("Could not load a Kubernetes config")
+
+
+def namespace() -> str:
+    """Get current namespace if available."""
+    if not os.path.isfile(NAMESPACE_FILE):
+        LOGGER.warning("Not running in Kubernetes? Namespace file not found: %s", NAMESPACE_FILE)
+        etos_ns = os.getenv("ETOS_NAMESPACE")
+        if etos_ns:
+            LOGGER.warning("Defauling to environment variable 'ETOS_NAMESPACE': %s", etos_ns)
+        else:
+            LOGGER.warning("ETOS_NAMESPACE environment variable not set!")
+            raise RuntimeError("Failed to determine Kubernetes namespace!")
+        return etos_ns
+    with open(NAMESPACE_FILE, encoding="utf-8") as namespace_file:
+        return namespace_file.read()

--- a/python/src/etos_api/routers/logs/router.py
+++ b/python/src/etos_api/routers/logs/router.py
@@ -16,38 +16,19 @@
 """ETOS API log handler."""
 import asyncio
 import logging
-import os
 from uuid import UUID
 
 import httpx
 from fastapi import APIRouter, HTTPException
-from kubernetes import client, config
+from kubernetes import client
 from sse_starlette.sse import EventSourceResponse
 from starlette.requests import Request
+
+from etos_api.routers.lib.kubernetes import namespace
 
 NAMESPACE_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
 LOGGER = logging.getLogger(__name__)
 ROUTER = APIRouter()
-
-try:
-    config.load_incluster_config()
-except config.ConfigException:
-    try:
-        config.load_config()
-    except config.ConfigException:
-        LOGGER.warning("Could not load a Kubernetes config")
-
-
-def namespace() -> str:
-    """Get current namespace if available."""
-    if not os.path.isfile(NAMESPACE_FILE):
-        LOGGER.warning(
-            "Not running in Kubernetes. Cannot figure out namespace. "
-            "Defaulting to environment variable 'ETOS_NAMESPACE'."
-        )
-        return os.getenv("ETOS_NAMESPACE")
-    with open(NAMESPACE_FILE, encoding="utf-8") as namespace_file:
-        return namespace_file.read()
 
 
 @ROUTER.get("/logs/{uuid}", tags=["logs"])


### PR DESCRIPTION
### Applicable Issues

### Description of the Change

The change implements the handling of DELETE requests at the endpoint:

/etos/<suite_id>

Upon receiving a request to this endpoint, ETOS API deletes the corresponding Kubernetes job. If no job is found for the given suite id, a 404 response is returned.

### Alternate Designs

### Possible Drawbacks

- etosctl needs to be adapted for this change to prevent infinite waiting loop when its suite is aborted

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com
