### PR TITLE
Make sure we dump providers to JSON before writing

### DIFF
--- a/python/src/etos_api/library/providers/register.py
+++ b/python/src/etos_api/library/providers/register.py
@@ -46,20 +46,20 @@ class RegisterProviders:  # pylint:disable=too-few-public-methods
                 self.logger.info("Registering execution space provider: %s", provider)
                 self.validate(provider, execution_space_provider_schema(provider))
                 self.root.join(f"execution-space/{provider['execution_space']['id']}").write(
-                    provider
+                    json.dumps(provider)
                 )
 
         if os.getenv("LOG_AREA_PROVIDERS"):
             for provider in self.providers(Path(os.getenv("LOG_AREA_PROVIDERS"))):
                 self.logger.info("Registering log area provider: %s", provider)
                 self.validate(provider, log_area_provider_schema(provider))
-                self.root.join(f"log-area/{provider['log']['id']}").write(provider)
+                self.root.join(f"log-area/{provider['log']['id']}").write(json.dumps(provider))
 
         if os.getenv("IUT_PROVIDERS"):
             for provider in self.providers(Path(os.getenv("IUT_PROVIDERS"))):
                 self.logger.info("Registering IUT provider: %s", provider)
                 self.validate(provider, iut_provider_schema(provider))
-                self.root.join(f"iut/{provider['iut']['id']}").write(provider)
+                self.root.join(f"iut/{provider['iut']['id']}").write(json.dumps(provider))
 
     def providers(self, directory: Path) -> Iterator[dict]:
         """Read provider json files from a directory.


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->
#56 

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
Fix a problem where the providers could not be loaded for configuration when running tests.
The problem was that the text we write to ETCD could not be parsed to JSON which is what we do when configuring.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->
None really.. I could not even parse it using `jq` so it is not valid JSON at all.

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->
Nope

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
