### PR TITLE
Dependabot fixes

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -28,4 +28,4 @@ opentelemetry-instrumentation-fastapi==0.44b0
 opentelemetry-sdk~=1.21
 jsontas~=1.4
 packageurl-python~=0.11
-cryptography~=41.0
+cryptography>=42.0.4,<43.0.0

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     opentelemetry-sdk~=1.21
     jsontas~=1.4
     packageurl-python~=0.11
-    cryptography~=41.0
+    cryptography>=42.0.4,<43.0.0
 
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 python_requires = >=3.4


### PR DESCRIPTION
A few security problems were detected by dependabot with the cryptography package.
Manually updating versions as depenedabot does not work in this repository.