### PR TITLE
Fix authorization header parsing

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -24,7 +24,7 @@ kubernetes~=26.1
 sse-starlette~=1.6
 opentelemetry-api~=1.21
 opentelemetry-exporter-otlp~=1.21
-opentelemetry-instrumentation-fastapi==0.44b0
+opentelemetry-instrumentation-fastapi==0.45b0
 opentelemetry-sdk~=1.21
 jsontas~=1.4
 packageurl-python~=0.11

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     sse-starlette~=1.6
     opentelemetry-api~=1.21
     opentelemetry-exporter-otlp~=1.21
-    opentelemetry-instrumentation-fastapi==0.44b0
+    opentelemetry-instrumentation-fastapi==0.45b0
     opentelemetry-sdk~=1.21
     jsontas~=1.4
     packageurl-python~=0.11

--- a/python/src/etos_api/library/docker.py
+++ b/python/src/etos_api/library/docker.py
@@ -177,7 +177,7 @@ class Docker:
                 self.logger.error("Error getting container image %r", exception)
                 digest = None
             except ValueError as exception:
-                self.logger.error(f"Failed to authenticate with container registry: {exception}")
+                self.logger.error("Failed to authenticate with container registry: %r", exception)
                 digest = None
         self.logger.info("Returning digest %r from %r", digest, manifest_url)
         return digest

--- a/python/src/etos_api/library/docker.py
+++ b/python/src/etos_api/library/docker.py
@@ -79,9 +79,9 @@ class Docker:
         :param response: HTTP response to get headers from.
         :return: Response JSON from authorization request.
         """
-        header = response.headers.get("www-authenticate")
-        header = header.replace("Bearer ", "")
-        parts = header.split(",")
+        www_auth_header = response.headers.get("www-authenticate")
+        challenge = www_auth_header.replace("Bearer ", "")
+        parts = challenge.split(",")
 
         url = None
         query = {}
@@ -91,6 +91,9 @@ class Docker:
                 url = value.strip('"')
             else:
                 query[key] = value.strip('"')
+
+        if not url:
+            raise ValueError(f"No realm found in www-authenticate header: {www_auth_header}")
 
         async with session.get(url, params=query) as response:
             response.raise_for_status()
@@ -172,6 +175,9 @@ class Docker:
                 digest = response.headers.get("Docker-Content-Digest")
             except aiohttp.ClientResponseError as exception:
                 self.logger.error("Error getting container image %r", exception)
+                digest = None
+            except ValueError as exception:
+                self.logger.error(f"Failed to authenticate with container registry: {exception}")
                 digest = None
         self.logger.info("Returning digest %r from %r", digest, manifest_url)
         return digest

--- a/python/src/etos_api/routers/etos/router.py
+++ b/python/src/etos_api/routers/etos/router.py
@@ -23,7 +23,6 @@ from etos_lib import ETOS
 from fastapi import APIRouter, HTTPException
 from kubernetes import client
 from opentelemetry import trace
-from opentelemetry.trace import Status, StatusCode
 
 from etos_api.library.environment import Configuration, configure_testrun
 from etos_api.library.utilities import sync_to_async
@@ -39,19 +38,19 @@ LOGGER = logging.getLogger(__name__)
 logging.getLogger("pika").setLevel(logging.WARNING)
 
 
-async def validate_suite(test_suite_url: str, span: "Span") -> None:
+async def validate_suite(test_suite_url: str) -> None:
     """Validate the ETOS test suite through the SuiteValidator.
 
     :param test_suite_url: The URL to the test suite to validate.
     """
+    span = trace.get_current_span()
+
     try:
         await SuiteValidator().validate(test_suite_url)
     except AssertionError as exception:
         LOGGER.error("Test suite validation failed!")
         LOGGER.error(exception)
         span.add_event("Test suite validation failed")
-        span.set_status(Status(StatusCode.ERROR, "Test suite validation failed"))
-        span.record_exception(exception)
         raise HTTPException(
             status_code=400, detail=f"Test suite validation failed. {exception}"
         ) from exception
@@ -69,7 +68,7 @@ async def _start(etos: StartEtosRequest, span: "Span") -> dict:
     span.set_attribute("etos.id", tercc.meta.event_id)
 
     LOGGER.info("Validating test suite.")
-    await validate_suite(etos.test_suite_url, span)
+    await validate_suite(etos.test_suite_url)
     LOGGER.info("Test suite validated.")
 
     etos_library = ETOS("ETOS API", os.getenv("HOSTNAME"), "ETOS API")


### PR DESCRIPTION
### Description of the Change
This pull request fixes an issue with parsing the authorization header in the `authorize` function. It handles cases where the `www-authenticate` header is malformed and raises a `ValueError` if no realm is found in the header. Additionally, it adds error handling for failed authentication with the container registry in the `digest` function. The pull request also includes changes to the `validate_suite` function to add OpenTelemetry events for better tracing and error reporting.

### Sign-off
Fredrik Fristedt <<fredrik.fristedt@axis.com>>
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fredrik Fristedt <<fredrik.fristedt@axis.com>>
