### PR TITLE
Use Debian Bookworm base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.9-buster AS build
+FROM python:3.9-bookworm AS build
 
 COPY . /src
 WORKDIR /src/python
 RUN python3 setup.py bdist_wheel
 
-FROM python:3.9-slim-buster
+FROM python:3.9-slim-bookworm
 ARG TZ
 ENV TZ=$TZ
 

--- a/deploy/etos-sse/Dockerfile
+++ b/deploy/etos-sse/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.20-alpine AS build
 WORKDIR /tmp/sse
 COPY . .
-RUN apk add --no-cache make=4.4.1-r2 git=2.43.0-r0 && make build
+RUN apk add --no-cache make=4.4.1-r2 git=2.43.4-r0 && make build
 
 FROM alpine:3.17.3
 ARG TZ


### PR DESCRIPTION
### Applicable Issues

- https://github.com/eiffel-community/etos/issues/235

### Description of the Change

This change migrates etos-api to Python 3.9 image based on Debian Bookworm.


### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com