### PR TITLE
Add retry for testrunner validation

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -24,7 +24,7 @@ kubernetes~=26.1
 sse-starlette~=1.6
 opentelemetry-api~=1.21
 opentelemetry-exporter-otlp~=1.21
-opentelemetry-instrumentation-fastapi~=0.45b0
+opentelemetry-instrumentation-fastapi==0.46b0
 opentelemetry-sdk~=1.21
 jsontas~=1.4
 packageurl-python~=0.11

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     sse-starlette~=1.6
     opentelemetry-api~=1.21
     opentelemetry-exporter-otlp~=1.21
-    opentelemetry-instrumentation-fastapi~=0.45b0
+    opentelemetry-instrumentation-fastapi==0.46b0
     opentelemetry-sdk~=1.21
     jsontas~=1.4
     packageurl-python~=0.11

--- a/python/src/etos_api/library/validator.py
+++ b/python/src/etos_api/library/validator.py
@@ -194,7 +194,7 @@ class SuiteValidator:
             docker = Docker()
             for test_runner in test_runners:
                 for _ in range(3):
-                    result = await docker.pull(test_runner)
+                    result = await docker.digest(test_runner)
                     if result:
                         break
 

--- a/python/src/etos_api/library/validator.py
+++ b/python/src/etos_api/library/validator.py
@@ -193,11 +193,16 @@ class SuiteValidator:
                         test_runners.add(constraint.value)
             docker = Docker()
             for test_runner in test_runners:
-                for _ in range(3):
+                for attempt in range(3):
                     result = await docker.digest(test_runner)
                     if result:
                         break
-
+                    else:
+                        self.logger.warning(
+                            "Test runner %s validation unsuccessful, retrying %d more times",
+                            test_runner,
+                            3 - attempt,
+                        )
                     await asyncio.sleep(random.randint(1, 3 ))
 
                 assert (

--- a/python/src/etos_api/library/validator.py
+++ b/python/src/etos_api/library/validator.py
@@ -197,14 +197,12 @@ class SuiteValidator:
                     result = await docker.digest(test_runner)
                     if result:
                         break
-                    else:
-                        self.logger.warning(
-                            "Test runner %s validation unsuccessful, retrying %d more times",
-                            test_runner,
-                            3 - attempt,
-                        )
-                    await asyncio.sleep(random.randint(1, 3 ))
 
-                assert (
-                    result is not None
-                ), f"Test runner {test_runner} not found"
+                    self.logger.warning(
+                        "Test runner %s validation unsuccessful, retrying %d more times",
+                        test_runner,
+                        3 - attempt,
+                    )
+                    await asyncio.sleep(random.randint(1, 3))
+
+                assert result is not None, f"Test runner {test_runner} not found"

--- a/python/src/etos_api/library/validator.py
+++ b/python/src/etos_api/library/validator.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 """ETOS API suite validator module."""
 import logging
+import asyncio
+import random
 from typing import List, Union
 from uuid import UUID
 
@@ -191,6 +193,13 @@ class SuiteValidator:
                         test_runners.add(constraint.value)
             docker = Docker()
             for test_runner in test_runners:
+                for _ in range(3):
+                    result = await docker.pull(test_runner)
+                    if result:
+                        break
+
+                    await asyncio.sleep(random.randint(1, 3 ))
+
                 assert (
-                    await docker.digest(test_runner) is not None
+                    result is not None
                 ), f"Test runner {test_runner} not found"


### PR DESCRIPTION
### Description of the Change
Adding retry when validation test runners withing test suite validation. This will increase resilience against random network outages and other intermittent non-permanent network related problems.

### Alternate Designs
I could have added the retries on several places in the code as there are chains of head requests made throughout the validation code. Although since the validation is fairly quick i opted for one retry to rule them all.

### Possible Drawbacks
The backoff is currently very rudimentary and short lived, we will not "survive" longer outages with the current code.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fredrik Fristedt <<fredrik.fristedt@axis.com>>
