### PR TITLE
Step up etos_lib to 4.3.1

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -24,7 +24,7 @@ kubernetes~=26.1
 sse-starlette~=1.6
 opentelemetry-api~=1.21
 opentelemetry-exporter-otlp~=1.21
-opentelemetry-instrumentation-fastapi==0.45b0
+opentelemetry-instrumentation-fastapi==0.46b0
 opentelemetry-sdk~=1.21
 jsontas~=1.4
 packageurl-python~=0.11

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -24,7 +24,7 @@ kubernetes~=26.1
 sse-starlette~=1.6
 opentelemetry-api~=1.21
 opentelemetry-exporter-otlp~=1.21
-opentelemetry-instrumentation-fastapi==0.46b0
+opentelemetry-instrumentation-fastapi~=0.45b0
 opentelemetry-sdk~=1.21
 jsontas~=1.4
 packageurl-python~=0.11

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -12,7 +12,7 @@
 # pip install -r requirements.txt
 # Remember to also add them in setup.cfg but unpinned.
 
-etos_lib==4.1.1
+etos_lib==4.3.1
 etcd3gw~=2.3
 pyscaffold~=4.4
 uvicorn~=0.22

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     sse-starlette~=1.6
     opentelemetry-api~=1.21
     opentelemetry-exporter-otlp~=1.21
-    opentelemetry-instrumentation-fastapi==0.45b0
+    opentelemetry-instrumentation-fastapi==0.46b0
     opentelemetry-sdk~=1.21
     jsontas~=1.4
     packageurl-python~=0.11

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -24,7 +24,7 @@ package_dir =
 # DON'T CHANGE THE FOLLOWING LINE! IT WILL BE UPDATED BY PYSCAFFOLD!
 setup_requires = pyscaffold>=3.2a0,<3.3a0
 install_requires =
-    etos_lib==4.1.1
+    etos_lib==4.3.1
     etcd3gw~=2.3
     pyscaffold~=4.4
     uvicorn~=0.22

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     sse-starlette~=1.6
     opentelemetry-api~=1.21
     opentelemetry-exporter-otlp~=1.21
-    opentelemetry-instrumentation-fastapi==0.46b0
+    opentelemetry-instrumentation-fastapi~=0.45b0
     opentelemetry-sdk~=1.21
     jsontas~=1.4
     packageurl-python~=0.11


### PR DESCRIPTION
### Applicable Issues

- https://github.com/eiffel-community/etos/issues/236

### Description of the Change

This change updates etos_lib to 4.3.1 which will add field opentelemetry_trace_id to all logstash entries from etos-api. 

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com