### PR TITLE
Add validation for empty suite definition list

### DIFF
--- a/python/src/etos_api/library/validator.py
+++ b/python/src/etos_api/library/validator.py
@@ -184,6 +184,9 @@ class SuiteValidator:
         """
         span = trace.get_current_span()
         downloaded_suite = await self._download_suite(test_suite_url)
+        assert (
+            len(downloaded_suite) > 0
+        ), "Test suite definition unsuccessful - Reason: Empty Test suite definition list"
         for suite_json in downloaded_suite:
             test_runners = set()
             suite = Suite(**suite_json)


### PR DESCRIPTION
We currently pass validation on suite defintions that only
contain an empty list. This should not pass. This change adds a
simple assertion to make sure the suite definition array is not
empty incl. a small test to verify this behavior.