### PR TITLE
Add validation for empty suite definition list

### DIFF
--- a/python/src/etos_api/library/validator.py
+++ b/python/src/etos_api/library/validator.py
@@ -184,6 +184,9 @@ class SuiteValidator:
         """
         span = trace.get_current_span()
         downloaded_suite = await self._download_suite(test_suite_url)
+        assert (
+            len(downloaded_suite) > 0
+        ), "Test suite definition unsuccessful - Reason: Empty Test suite definition list"
         for suite_json in downloaded_suite:
             test_runners = set()
             suite = Suite(**suite_json)

--- a/python/src/etos_api/library/validator.py
+++ b/python/src/etos_api/library/validator.py
@@ -186,7 +186,7 @@ class SuiteValidator:
         downloaded_suite = await self._download_suite(test_suite_url)
         assert (
             len(downloaded_suite) > 0
-        ), "Test suite definition unsuccessful - Reason: Empty Test suite definition list"
+        ), "Suite definition validation unsuccessful - Reason: Empty Test suite definition list"
         for suite_json in downloaded_suite:
             test_runners = set()
             suite = Suite(**suite_json)


### PR DESCRIPTION
### Applicable Issues
eiffel-community/etos#254

### Description of the Change
We currently pass validation on suite definition that only contain an empty list. This should not pass. This change adds a simple assertion to make sure the suite definition array is not empty incl. a small test to verify this behavior.

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fredrik Fristedt <<fredrik.fristedt@axis.com>>
