### PR TITLE
Add Github publishing workflow for etos-iut

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -150,4 +150,4 @@ jobs:
           }
         branch: main
         commitChange: true
-        message: Updating SSE image to ${{ needs.build_sse.outputs.sseVersion }}, LogArea image to ${{ needs.build_logarea.outputs.logAreaVersion }}, IUT image to ${{ needs.build_iut.outputs.iutVersion }}  API image to ${{ needs.build_api.outputs.apiVersion }}
+        message: Updating SSE image to ${{ needs.build_sse.outputs.sseVersion }}, LogArea image to ${{ needs.build_logarea.outputs.logAreaVersion }}, IUT image to ${{ needs.build_iut.outputs.iutVersion }} and API image to ${{ needs.build_api.outputs.apiVersion }}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -95,6 +95,36 @@ jobs:
         echo "::set-output name=version::$VERSION"
     outputs:
       logAreaVersion: ${{ steps.image.outputs.version }}
+  build_iut:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build app image
+      run: docker build . -f deploy/etos-iut/Dockerfile --tag image
+
+    - name: Log into registry
+      run: echo "${{ secrets.REGISTRYPASSWORD }}" | docker login registry.nordix.org -u ${{ secrets.REGISTRYUSERNAME }} --password-stdin
+
+    - name: Push app image
+      id: image
+      run: |
+        IMAGE_ID=registry.nordix.org/eiffel/etos-iut
+        # Strip git ref prefix from version
+        VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+        # Strip "v" prefix from tag name
+        [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+        # Use Docker `latest` tag convention
+        [ "$VERSION" == "main" ] && VERSION=$(echo ${{ github.sha }} | cut -c1-8)
+        echo IMAGE_ID=$IMAGE_ID
+        echo VERSION=$VERSION
+        docker tag image $IMAGE_ID:$VERSION
+        docker push $IMAGE_ID:$VERSION
+        echo $IMAGE_ID:$VERSION
+        echo "::set-output name=version::$VERSION"
+    outputs:
+      logAreaVersion: ${{ steps.image.outputs.version }}
+
   update_manifests:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -123,8 +123,7 @@ jobs:
         echo $IMAGE_ID:$VERSION
         echo "::set-output name=version::$VERSION"
     outputs:
-      logAreaVersion: ${{ steps.image.outputs.version }}
-
+      IutVersion: ${{ steps.image.outputs.version }}
   update_manifests:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
@@ -144,8 +143,11 @@ jobs:
             },
             "manifests/base/logarea/deployment.yaml": {
               "spec.template.spec.containers[0].image": "registry.nordix.org/eiffel/etos-logarea:${{ needs.build_logarea.outputs.logAreaVersion }}"
+            },
+            "manifests/base/iut/deployment.yaml": {
+              "spec.template.spec.containers[0].image": "registry.nordix.org/eiffel/etos-iut:${{ needs.build_iut.outputs.IutVersion }}"
             }
           }
         branch: main
         commitChange: true
-        message: Updating SSE image to ${{ needs.build_sse.outputs.sseVersion }}, LogArea image to ${{ needs.build_logarea.outputs.logAreaVersion }} and API image to ${{ needs.build_api.outputs.apiVersion }}
+        message: Updating SSE image to ${{ needs.build_sse.outputs.sseVersion }}, LogArea image to ${{ needs.build_logarea.outputs.logAreaVersion }}, IUT image to ${{ needs.build_iut.outputs.IutVersion }}  API image to ${{ needs.build_api.outputs.apiVersion }}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -123,7 +123,7 @@ jobs:
         echo $IMAGE_ID:$VERSION
         echo "::set-output name=version::$VERSION"
     outputs:
-      IutVersion: ${{ steps.image.outputs.version }}
+      iutVersion: ${{ steps.image.outputs.version }}
   update_manifests:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
@@ -145,9 +145,9 @@ jobs:
               "spec.template.spec.containers[0].image": "registry.nordix.org/eiffel/etos-logarea:${{ needs.build_logarea.outputs.logAreaVersion }}"
             },
             "manifests/base/iut/deployment.yaml": {
-              "spec.template.spec.containers[0].image": "registry.nordix.org/eiffel/etos-iut:${{ needs.build_iut.outputs.IutVersion }}"
+              "spec.template.spec.containers[0].image": "registry.nordix.org/eiffel/etos-iut:${{ needs.build_iut.outputs.iutVersion }}"
             }
           }
         branch: main
         commitChange: true
-        message: Updating SSE image to ${{ needs.build_sse.outputs.sseVersion }}, LogArea image to ${{ needs.build_logarea.outputs.logAreaVersion }}, IUT image to ${{ needs.build_iut.outputs.IutVersion }}  API image to ${{ needs.build_api.outputs.apiVersion }}
+        message: Updating SSE image to ${{ needs.build_sse.outputs.sseVersion }}, LogArea image to ${{ needs.build_logarea.outputs.logAreaVersion }}, IUT image to ${{ needs.build_iut.outputs.iutVersion }}  API image to ${{ needs.build_api.outputs.apiVersion }}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -127,7 +127,7 @@ jobs:
   update_manifests:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
-    needs: [build_api, build_sse, build_logarea]
+    needs: [build_api, build_sse, build_logarea, build_iut]
     steps:
     - uses: actions/checkout@v3
     - name: Update manifests


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/261
 
### Description of the Change

This change adds a Github workflow to publish ETOS IUT Provider images in the same way as it is done for Log Area Provider and SSE.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com
