### PR TITLE
Improve defer response.Body.Close() in SSE

### DIFF
--- a/pkg/sse/v1/sse.go
+++ b/pkg/sse/v1/sse.go
@@ -138,10 +138,10 @@ func GetFrom(ctx context.Context, url string, id string) ([]events.Event, error)
 	if err != nil {
 		return nil, err
 	}
+	defer response.Body.Close()
 
 	etosEvents := []events.Event{}
 	scanner := bufio.NewScanner(response.Body)
-	defer response.Body.Close()
 	for scanner.Scan() {
 		event, err := events.New(scanner.Bytes())
 		if err != nil {
@@ -169,12 +169,12 @@ func GetOne(ctx context.Context, url string, id string) (events.Event, error) {
 	if err != nil {
 		return event, err
 	}
+	defer response.Body.Close() // make sure the body is closed if io.ReadAll returns error
 
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return event, err
 	}
-	defer response.Body.Close()
 	return events.New(body)
 }
 

--- a/pkg/sse/v1/sse.go
+++ b/pkg/sse/v1/sse.go
@@ -154,7 +154,7 @@ func GetFrom(ctx context.Context, url string, id string) ([]events.Event, error)
 }
 
 // GetOne gets a single event from an ESR instance.
-func GetOne(ctx context.Context, url string, id string) (events.Event, error) {
+func GetOne(ctx context.Context, logger *logrus.Entry, url string, id string) (events.Event, error) {
 	event := events.Event{}
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -169,10 +169,11 @@ func GetOne(ctx context.Context, url string, id string) (events.Event, error) {
 	if err != nil {
 		return event, err
 	}
-	defer response.Body.Close() // make sure the body is closed if io.ReadAll returns error
+	defer response.Body.Close()
 
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
+		logger.Errorf("Request failed (could not read response body): %+v", request)
 		return event, err
 	}
 	return events.New(body)
@@ -208,7 +209,7 @@ func (h SSEHandler) GetEvent(w http.ResponseWriter, r *http.Request, ps httprout
 		return
 	}
 
-	event, err := GetOne(r.Context(), url, counter)
+	event, err := GetOne(r.Context(), logger, url, counter)
 	if err != nil {
 		logger.Error(err)
 		// TODO: Message client


### PR DESCRIPTION
### Applicable Issues

- https://github.com/eiffel-community/etos/issues/282

### Description of the Change

This change makes minor improvements in the SSE server to prevent memory leaks.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com