### PR TITLE
More robust testrunner validation retry logic

### DIFF
--- a/python/src/etos_api/library/docker.py
+++ b/python/src/etos_api/library/docker.py
@@ -92,7 +92,9 @@ class Docker:
             else:
                 query[key] = value.strip('"')
 
-        if not isinstance(url, str) or not (url.startswith("http://") or url.startswith("https://")):
+        if not isinstance(url, str) or not (
+            url.startswith("http://") or url.startswith("https://")
+        ):
             raise ValueError(f"No realm URL found in www-authenticate header: {www_auth_header}")
 
         async with session.get(url, params=query) as response:

--- a/python/src/etos_api/library/docker.py
+++ b/python/src/etos_api/library/docker.py
@@ -92,8 +92,8 @@ class Docker:
             else:
                 query[key] = value.strip('"')
 
-        if not url:
-            raise ValueError(f"No realm found in www-authenticate header: {www_auth_header}")
+        if not isinstance(url, str) or not (url.startswith("http://") or url.startswith("https://")):
+            raise ValueError(f"No realm URL found in www-authenticate header: {www_auth_header}")
 
         async with session.get(url, params=query) as response:
             response.raise_for_status()

--- a/python/src/etos_api/library/validator.py
+++ b/python/src/etos_api/library/validator.py
@@ -16,7 +16,6 @@
 """ETOS API suite validator module."""
 import logging
 import asyncio
-import random
 from typing import List, Union
 from uuid import UUID
 

--- a/python/src/etos_api/library/validator.py
+++ b/python/src/etos_api/library/validator.py
@@ -198,18 +198,21 @@ class SuiteValidator:
                         test_runners.add(constraint.value)
             docker = Docker()
             for test_runner in test_runners:
-                for attempt in range(3):
+                for attempt in range(5):
+                    if attempt > 0:
+                        span.add_event(
+                            f"Test runner validation unsuccessful, retry #{attempt}"
+                        )
+                        self.logger.warning(
+                            "Test runner %s validation unsuccessful, retry #%d",
+                            test_runner,
+                            attempt,
+                        )
                     result = await docker.digest(test_runner)
                     if result:
                         break
-                    span.add_event(
-                        f"Test runner validation unsuccessful, retrying {3 - attempt} more times"
-                    )
-                    self.logger.warning(
-                        "Test runner %s validation unsuccessful, retrying %d more times",
-                        test_runner,
-                        3 - attempt,
-                    )
-                    await asyncio.sleep(random.randint(1, 3))
+                    # Total wait time with 5 attempts: 55 seconds
+                    sleep_time = (attempt + 1) ** 2
+                    await asyncio.sleep(sleep_time)
 
                 assert result is not None, f"Test runner {test_runner} not found"

--- a/python/src/etos_api/library/validator.py
+++ b/python/src/etos_api/library/validator.py
@@ -199,9 +199,7 @@ class SuiteValidator:
             for test_runner in test_runners:
                 for attempt in range(5):
                     if attempt > 0:
-                        span.add_event(
-                            f"Test runner validation unsuccessful, retry #{attempt}"
-                        )
+                        span.add_event(f"Test runner validation unsuccessful, retry #{attempt}")
                         self.logger.warning(
                             "Test runner %s validation unsuccessful, retry #%d",
                             test_runner,


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/286

### Description of the Change
This change increases the number of test runner validation attempts and adds exponential backoff sleep time between retries.

### Alternate Designs

### Possible Drawbacks

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com