### PR TITLE
Lazy testrunner validation

### DIFF
--- a/python/src/etos_api/library/validator.py
+++ b/python/src/etos_api/library/validator.py
@@ -97,7 +97,7 @@ class TestRunnerValidationCache:
         timestamp = cls.get_timestamp(test_runner)
         if timestamp is None:
             return False
-        return (timestamp + cls.TESTRUNNER_VALIDATION_WINDOW) < time.time()
+        return (timestamp + cls.TESTRUNNER_VALIDATION_WINDOW) > time.time()
 
 
 class Environment(BaseModel):

--- a/python/src/etos_api/library/validator.py
+++ b/python/src/etos_api/library/validator.py
@@ -18,6 +18,7 @@ import logging
 import asyncio
 import time
 from typing import List, Union
+from threading import Lock
 from uuid import UUID
 
 import requests
@@ -32,10 +33,71 @@ from etos_api.library.docker import Docker
 
 # pylint:disable=too-few-public-methods
 
-# Cache for lazy testrunner validation. Keys: container names, values: timestamp.
-# Only passed validations are cached.
-TESTRUNNER_VALIDATION_CACHE = {}
-TESTRUNNER_VALIDATION_WINDOW = 1800
+
+class TestRunnerValidationCache:
+    """Lazy test runner validation via in-memory cache."""
+
+    # Cache for lazy testrunner validation. Keys: container names, values: timestamp.
+    # Only passed validations are cached.
+    TESTRUNNER_VALIDATION_CACHE = {}
+    TESTRUNNER_VALIDATION_WINDOW = 1800  # seconds
+
+    lock = Lock()
+
+    @classmethod
+    def get_timestamp(cls, test_runner: str) -> Union[float, None]:
+        """Get latest passed validation timestamp for the given testrunner.
+
+        :param test_runner: test runner container name
+        :type test_runner: str
+        :return: validation timestamp or none if not found
+        :rtype: float or NoneType
+        """
+        with cls.lock:
+            if test_runner in cls.TESTRUNNER_VALIDATION_CACHE:
+                return cls.TESTRUNNER_VALIDATION_CACHE[test_runner]
+        return None
+
+    @classmethod
+    def set_timestamp(cls, test_runner: str, timestamp: float) -> None:
+        """Set passed validation timestamp for the given testrunner.
+
+        :param test_runner: test runner container name
+        :type test_runner: str
+        :param timestamp: test runner container name
+        :type timestamp: float
+        :return: none
+        :rtype: NoneType
+        """
+        with cls.lock:
+            cls.TESTRUNNER_VALIDATION_CACHE[test_runner] = timestamp
+
+    @classmethod
+    def remove(cls, test_runner: str) -> None:
+        """Remove the given test runner from the validation cache.
+
+        :param test_runner: test runner container name
+        :type test_runner: str
+        :return: none
+        :rtype: NoneType
+        """
+        with cls.lock:
+            if test_runner in cls.TESTRUNNER_VALIDATION_CACHE:
+                del cls.TESTRUNNER_VALIDATION_CACHE[test_runner]
+
+    @classmethod
+    def is_test_runner_valid(cls, test_runner: str) -> bool:
+        """Determine if the given test runner is valid.
+
+        :param test_runner: test runner container name
+        :type test_runner: str
+        :return: validation result from cache
+        :rtype: bool
+        """
+        timestamp = cls.get_timestamp(test_runner)
+        if timestamp is None:
+            return False
+        return (timestamp + cls.TESTRUNNER_VALIDATION_WINDOW) < time.time()
 
 
 class Environment(BaseModel):
@@ -203,15 +265,9 @@ class SuiteValidator:
                         test_runners.add(constraint.value)
             docker = Docker()
             for test_runner in test_runners:
-                if test_runner in TESTRUNNER_VALIDATION_CACHE:
-                    timestamp = TESTRUNNER_VALIDATION_CACHE[test_runner]
-                    if (timestamp + TESTRUNNER_VALIDATION_WINDOW) > time.time():
-                        self.logger.info(
-                            "Using cached testrunner validation result: %s", test_runner
-                        )
-                        continue
-                    del TESTRUNNER_VALIDATION_CACHE[test_runner]
-
+                if TestRunnerValidationCache.is_test_runner_valid(test_runner):
+                    self.logger.info("Using cached test runner validation result: %s", test_runner)
+                    continue
                 for attempt in range(5):
                     if attempt > 0:
                         span.add_event(f"Test runner validation unsuccessful, retry #{attempt}")
@@ -223,7 +279,7 @@ class SuiteValidator:
                     result = await docker.digest(test_runner)
                     if result:
                         # only passed validations shall be cached
-                        TESTRUNNER_VALIDATION_CACHE[test_runner] = time.time()
+                        TestRunnerValidationCache.set_timestamp(test_runner, time.time())
                         break
                     # Total wait time with 5 attempts: 55 seconds
                     sleep_time = (attempt + 1) ** 2

--- a/python/src/etos_api/library/validator.py
+++ b/python/src/etos_api/library/validator.py
@@ -97,7 +97,10 @@ class TestRunnerValidationCache:
         timestamp = cls.get_timestamp(test_runner)
         if timestamp is None:
             return False
-        return (timestamp + cls.TESTRUNNER_VALIDATION_WINDOW) > time.time()
+        if (timestamp + cls.TESTRUNNER_VALIDATION_WINDOW) > time.time():
+            return True
+        cls.remove(test_runner)
+        return False
 
 
 class Environment(BaseModel):


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/286

### Description of the Change

This change adds a simple in-memory cache for testrunner validation results to decrease the number of requests to Docker registry.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by:  Andrei Matveyeu, andrei.matveyeu@axis.com