### PR TITLE
Go 1.22 for all etos-api services

### DIFF
--- a/deploy/etos-iut/Dockerfile
+++ b/deploy/etos-iut/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine AS build
+FROM golang:1.22-alpine AS build
 WORKDIR /tmp/iut
 COPY . .
 RUN apk add --no-cache make=4.4.1-r2 git=2.45.2-r0 && make iut

--- a/deploy/etos-iut/Dockerfile.dev
+++ b/deploy/etos-iut/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.22
 WORKDIR /app
 
 COPY ./go.mod ./go.sum ./

--- a/deploy/etos-logarea/Dockerfile.dev
+++ b/deploy/etos-logarea/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.22
 WORKDIR /app
 
 COPY ./go.mod ./go.sum ./

--- a/deploy/etos-sse/Dockerfile.dev
+++ b/deploy/etos-sse/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.22
 WORKDIR /app
 
 COPY ./go.mod ./go.sum ./


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/287

### Description of the Change

This change migrates all etos-api Dockerfiles to Go 1.22 base image. This is needed because all etos-api services share the same go.mod file.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com