### PR TITLE
Use the common etcd client in etos-iut

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -22,7 +22,12 @@ import (
 	"github.com/google/uuid"
 )
 
+type DatabaseReadWriter interface {
+	io.ReadWriter
+	Delete() error
+}
+
 // Opener is the common interface for database clients
 type Opener interface {
-	Open(context.Context, uuid.UUID) io.ReadWriter
+	Open(context.Context, uuid.UUID) DatabaseReadWriter
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -22,9 +22,12 @@ import (
 	"github.com/google/uuid"
 )
 
+type Deleter interface {
+	Delete() error
+}
+
 type DatabaseReadWriter interface {
 	io.ReadWriter
-	Delete() error
 }
 
 // Opener is the common interface for database clients

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -26,11 +26,7 @@ type Deleter interface {
 	Delete() error
 }
 
-type DatabaseReadWriter interface {
-	io.ReadWriter
-}
-
 // Opener is the common interface for database clients
 type Opener interface {
-	Open(context.Context, uuid.UUID) DatabaseReadWriter
+	Open(context.Context, uuid.UUID) io.ReadWriter
 }

--- a/internal/database/etcd/etcd.go
+++ b/internal/database/etcd/etcd.go
@@ -60,7 +60,7 @@ func New(cfg config.Config, logger *logrus.Logger, treePrefix string) database.O
 }
 
 // Open returns a copy of an Etcd client with ID and context added
-func (etcd Etcd) Open(ctx context.Context, id uuid.UUID) database.DatabaseReadWriter {
+func (etcd Etcd) Open(ctx context.Context, id uuid.UUID) io.ReadWriter {
 	return &Etcd{
 		client: etcd.client,
 		cfg:    etcd.cfg,
@@ -69,7 +69,7 @@ func (etcd Etcd) Open(ctx context.Context, id uuid.UUID) database.DatabaseReadWr
 	}
 }
 
-// Write writes data to etcd. If data is nil, the current key will be deleted from the database.
+// Write writes data to etcd.
 func (etcd Etcd) Write(p []byte) (int, error) {
 	if etcd.ID == uuid.Nil {
 		return 0, errors.New("please create a new etcd client using Open")

--- a/internal/database/etcd/etcd.go
+++ b/internal/database/etcd/etcd.go
@@ -69,7 +69,7 @@ func (etcd Etcd) Open(ctx context.Context, id uuid.UUID) io.ReadWriter {
 	}
 }
 
-// Write writes data to etcd.
+// Write writes data to etcd
 func (etcd Etcd) Write(p []byte) (int, error) {
 	if etcd.ID == uuid.Nil {
 		return 0, errors.New("please create a new etcd client using Open")

--- a/internal/database/etcd/etcd.go
+++ b/internal/database/etcd/etcd.go
@@ -122,7 +122,13 @@ func (etcd *Etcd) Read(p []byte) (n int, err error) {
 	}
 
 	// Copy as much data as possible to p
+	// The copy function copies the minimum of len(p) and len(etcd.data) bytes from etcd.data to p
+	// It returns the number of bytes copied, which is stored in n
 	n = copy(p, etcd.data)
+
+	// Update etcd.data to remove the portion of data that has already been copied to p
+	// etcd.data[n:] creates a new slice that starts from the n-th byte to the end of the original slice
+	// This effectively removes the first n bytes from etcd.data, ensuring that subsequent reads start from the correct position
 	etcd.data = etcd.data[n:]
 
 	if n == 0 {
@@ -131,38 +137,3 @@ func (etcd *Etcd) Read(p []byte) (n int, err error) {
 
 	return n, nil
 }
-
-// func (etcd *Etcd) Read(p []byte) (n int, err error) {
-// 	if etcd.ID == uuid.Nil {
-// 		err = errors.New("please create a new etcd client using NewWithID")
-// 		return n, err
-// 	}
-
-// 	key := fmt.Sprintf("%s/%s", etcd.treePrefix, etcd.ID.String())
-
-// 	if !etcd.hasRead {
-// 		resp, err := etcd.client.Get(etcd.ctx, key)
-// 		if err != nil {
-// 			return n, err
-// 		}
-// 		if len(resp.Kvs) == 0 {
-// 			return n, io.EOF
-// 		}
-// 		etcd.data = resp.Kvs[0].Value
-// 		etcd.hasRead = true
-// 	}
-
-// 	if len(etcd.data) == 0 {
-// 		return n, io.EOF
-// 	}
-// 	if c := cap(p); c > 0 {
-// 		for n < c {
-// 			p[n] = etcd.readByte()
-// 			n++
-// 			if len(etcd.data) == 0 {
-// 				return n, io.EOF
-// 			}
-// 		}
-// 	}
-// 	return n, nil
-// }

--- a/internal/database/etcd/etcd.go
+++ b/internal/database/etcd/etcd.go
@@ -32,6 +32,7 @@ import (
 // TODO: refactor the client so that it does not store data it fetched.
 // However, without it implementing the database.Opener interface would be more complex (methods readByte, read).
 type Etcd struct {
+	database.Deleter
 	cfg        config.Config
 	client     *clientv3.Client
 	ID         uuid.UUID

--- a/pkg/iut/v1alpha1/v1alpha1.go
+++ b/pkg/iut/v1alpha1/v1alpha1.go
@@ -128,8 +128,6 @@ type StopRequest struct {
 func (h V1Alpha1Handler) Start(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	identifier, err := uuid.Parse(r.Header.Get("X-Etos-Id"))
 	logger := h.logger.WithField("identifier", identifier).WithContext(r.Context())
-	logger.Infof("Start request: start")
-
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, err.Error())
 	}
@@ -140,7 +138,7 @@ func (h V1Alpha1Handler) Start(w http.ResponseWriter, r *http.Request, ps httpro
 
 	var startReq StartRequest
 	if err := json.NewDecoder(r.Body).Decode(&startReq); err != nil {
-		h.logger.Errorf("Failed to decode request body: %s", r.Body)
+		logger.Errorf("Failed to decode request body: %s", r.Body)
 		RespondWithError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -157,9 +155,6 @@ func (h V1Alpha1Handler) Start(w http.ResponseWriter, r *http.Request, ps httpro
 	for i := range purls {
 		purls[i] = purl
 	}
-	logger.Infof("Purls: %s", purls)
-	logger.Infof("ArtifactIdentity: %s", startReq.ArtifactIdentity)
-
 	iuts, err := json.Marshal(purls)
 	if err != nil {
 		logger.Errorf("Failed to marshal purls: %s", purls)
@@ -177,8 +172,6 @@ func (h V1Alpha1Handler) Start(w http.ResponseWriter, r *http.Request, ps httpro
 	w.WriteHeader(http.StatusOK)
 	response, _ := json.Marshal(startResp)
 	_, _ = w.Write(response)
-	logger.Infof("Start request: end. Written: /iut/%s/%s", identifier, iuts)
-
 }
 
 // Status creates a simple DONE Status response with IUTs.
@@ -188,7 +181,6 @@ func (h V1Alpha1Handler) Status(w http.ResponseWriter, r *http.Request, ps httpr
 		RespondWithError(w, http.StatusInternalServerError, err.Error())
 	}
 	logger := h.logger.WithField("identifier", identifier).WithContext(r.Context())
-	logger.Infof("Status request: start")
 
 	id, err := uuid.Parse(r.URL.Query().Get("id"))
 	client := h.database.Open(r.Context(), identifier)
@@ -197,7 +189,6 @@ func (h V1Alpha1Handler) Status(w http.ResponseWriter, r *http.Request, ps httpr
 	byteCount, err := client.Read(data)
 	data = data[:byteCount]
 
-	logger.Infof("Reading /iut/%s, %d bytes", identifier, byteCount)
 	if err != nil {
 		logger.Errorf("Failed to look up status request id: %s, %s", identifier, err.Error())
 		RespondWithError(w, http.StatusInternalServerError, err.Error())
@@ -218,7 +209,6 @@ func (h V1Alpha1Handler) Status(w http.ResponseWriter, r *http.Request, ps httpr
 		RespondWithError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	logger.Infof("Status request: end")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(response)
 
@@ -227,8 +217,6 @@ func (h V1Alpha1Handler) Status(w http.ResponseWriter, r *http.Request, ps httpr
 // Stop deletes the given IUTs from the database and returns an empty response.
 func (h V1Alpha1Handler) Stop(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	identifier, err := uuid.Parse(r.Header.Get("X-Etos-Id"))
-	h.logger.Infof("Stop request: start")
-
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, err.Error())
 	}
@@ -248,7 +236,6 @@ func (h V1Alpha1Handler) Stop(w http.ResponseWriter, r *http.Request, ps httprou
 		RespondWithError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	h.logger.Infof("Stop request: end")
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/pkg/iut/v1alpha1/v1alpha1.go
+++ b/pkg/iut/v1alpha1/v1alpha1.go
@@ -121,11 +121,6 @@ type StatusRequest struct {
 	Id uuid.UUID `json:"id"`
 }
 
-type IUT struct {
-	Id uuid.UUID `json:"id"`
-}
-type StopRequest []IUT
-
 // Start creates a number of IUTs and stores them in the ETCD database returning a checkout ID.
 func (h V1Alpha1Handler) Start(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	identifier, err := uuid.Parse(r.Header.Get("X-Etos-Id"))
@@ -172,7 +167,7 @@ func (h V1Alpha1Handler) Start(w http.ResponseWriter, r *http.Request, ps httpro
 		return
 	}
 	startResp := StartResponse{Id: checkOutID}
-	logger.Infof("Start response: %s", startResp)
+	logger.Debugf("Start response: %s", startResp)
 	w.WriteHeader(http.StatusOK)
 	response, _ := json.Marshal(startResp)
 	_, _ = w.Write(response)
@@ -211,7 +206,7 @@ func (h V1Alpha1Handler) Status(w http.ResponseWriter, r *http.Request, ps httpr
 		RespondWithError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	logger.Infof("Status response: %s", statusResp)
+	logger.Debugf("Status response: %s", statusResp)
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(response)
 
@@ -224,27 +219,6 @@ func (h V1Alpha1Handler) Stop(w http.ResponseWriter, r *http.Request, ps httprou
 		RespondWithError(w, http.StatusInternalServerError, err.Error())
 	}
 	logger := h.logger.WithField("identifier", identifier).WithContext(r.Context())
-
-	var stopReq StopRequest
-	defer r.Body.Close()
-	if err := json.NewDecoder(r.Body).Decode(&stopReq); err != nil {
-		body, _err := io.ReadAll(r.Body)
-		if _err != nil {
-			logger.Errorf("Failed to read request body: %s -> %s", err, _err)
-		} else {
-			logger.Errorf("Bad delete request: %s, request body: '%s'", err.Error(), body)
-		}
-		RespondWithError(w, http.StatusBadRequest, err.Error())
-		return
-	}
-
-	stopReqJSON, err := json.Marshal(stopReq)
-	if err != nil {
-		logger.Errorf("Failed to marshal stopReq as JSON: %s", err.Error())
-		RespondWithError(w, http.StatusInternalServerError, err.Error())
-		return
-	}
-	logger.Infof("Stop request: %s", stopReqJSON)
 
 	client := h.database.Open(r.Context(), identifier)
 	deleter, canDelete := client.(database.Deleter)
@@ -260,7 +234,7 @@ func (h V1Alpha1Handler) Stop(w http.ResponseWriter, r *http.Request, ps httprou
 		RespondWithError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	logger.Infof("Stop request succeeded")
+	logger.Debugf("Stop request succeeded")
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/pkg/iut/v1alpha1/v1alpha1.go
+++ b/pkg/iut/v1alpha1/v1alpha1.go
@@ -237,6 +237,15 @@ func (h V1Alpha1Handler) Stop(w http.ResponseWriter, r *http.Request, ps httprou
 		RespondWithError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+
+	stopReqJSON, err := json.Marshal(stopReq)
+	if err != nil {
+		logger.Errorf("Failed to marshal stopReq as JSON: %s", err.Error())
+		RespondWithError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	logger.Infof("Stop request: %s", stopReqJSON)
+
 	client := h.database.Open(r.Context(), identifier)
 	deleter, canDelete := client.(database.Deleter)
 	if !canDelete {

--- a/pkg/iut/v1alpha1/v1alpha1.go
+++ b/pkg/iut/v1alpha1/v1alpha1.go
@@ -131,6 +131,7 @@ func (h V1Alpha1Handler) Start(w http.ResponseWriter, r *http.Request, ps httpro
 	logger := h.logger.WithField("identifier", identifier).WithContext(r.Context())
 	if err != nil {
 		RespondWithError(w, http.StatusInternalServerError, err.Error())
+		return
 	}
 	checkOutID := uuid.New()
 
@@ -228,8 +229,6 @@ func (h V1Alpha1Handler) Stop(w http.ResponseWriter, r *http.Request, ps httprou
 		RespondWithError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	// client := h.database.Open(r.Context(), identifier)
-
 	client := h.database.Open(r.Context(), identifier)
 	deleter, canDelete := client.(database.Deleter)
 	if !canDelete {

--- a/pkg/iut/v1alpha1/v1alpha1.go
+++ b/pkg/iut/v1alpha1/v1alpha1.go
@@ -146,7 +146,7 @@ func (h V1Alpha1Handler) Start(w http.ResponseWriter, r *http.Request, ps httpro
 	purl, err := packageurl.FromString(startReq.ArtifactIdentity)
 
 	if err != nil {
-		logger.Errorf("Failed to get purl from artifact identity: %s", startReq.ArtifactIdentity)
+		logger.Errorf("Failed to create a purl struct from artifact identity: %s", startReq.ArtifactIdentity)
 		RespondWithError(w, http.StatusBadRequest, err.Error())
 		return
 	}

--- a/python/test-requirements.txt
+++ b/python/test-requirements.txt
@@ -19,4 +19,4 @@ tox
 pytest
 pytest-cov
 pytest-asyncio
-httpx
+httpx==0.27.2  # latest compatible version with the current fastapi/starlette

--- a/python/test-requirements.txt
+++ b/python/test-requirements.txt
@@ -19,4 +19,4 @@ tox
 pytest
 pytest-cov
 pytest-asyncio
-httpx==0.27.2  # latest compatible version with the current fastapi/starlette
+httpx


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/283

### Description of the Change

This change migrates the generic ETOS IUT Provider to the common etcd client of ETOS API.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by:  Andrei Matveyeu, andrei.matveyeu@axis.com