### PR TITLE
Remove testrunner validation retries and cache

### DIFF
--- a/python/src/etos_api/library/docker.py
+++ b/python/src/etos_api/library/docker.py
@@ -92,10 +92,8 @@ class Docker:
             else:
                 query[key] = value.strip('"')
 
-        if not isinstance(url, str) or not (
-            url.startswith("http://") or url.startswith("https://")
-        ):
-            raise ValueError(f"No realm URL found in www-authenticate header: {www_auth_header}")
+        if not url:
+            raise ValueError(f"No realm found in www-authenticate header: {www_auth_header}")
 
         async with session.get(url, params=query) as response:
             response.raise_for_status()


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/286

### Description of the Change

This change removes testrunner validation retries and cache as they haven't proved useful.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com