### PR TITLE
Restore testrunner validation retries and cache

### DIFF
--- a/python/src/etos_api/library/validator.py
+++ b/python/src/etos_api/library/validator.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 """ETOS API suite validator module."""
 import logging
+import asyncio
+import time
 from typing import List, Union
 from uuid import UUID
 
@@ -24,10 +26,80 @@ import requests
 from pydantic import BaseModel  # pylint:disable=no-name-in-module
 from pydantic import ValidationError, conlist, constr, field_validator
 from pydantic.fields import PrivateAttr
+from opentelemetry import trace
 
 from etos_api.library.docker import Docker
 
 # pylint:disable=too-few-public-methods
+
+
+class TestRunnerValidationCache:
+    """Lazy test runner validation via in-memory cache."""
+
+    # Cache for lazy testrunner validation. Keys: container names, values: timestamp.
+    # Only passed validations are cached.
+    TESTRUNNER_VALIDATION_CACHE = {}
+    TESTRUNNER_VALIDATION_WINDOW = 1800  # seconds
+
+    lock = asyncio.Lock()
+
+    @classmethod
+    async def get_timestamp(cls, test_runner: str) -> Union[float, None]:
+        """Get latest passed validation timestamp for the given testrunner.
+
+        :param test_runner: test runner container name
+        :type test_runner: str
+        :return: validation timestamp or none if not found
+        :rtype: float or NoneType
+        """
+        async with cls.lock:
+            if test_runner in cls.TESTRUNNER_VALIDATION_CACHE:
+                return cls.TESTRUNNER_VALIDATION_CACHE[test_runner]
+        return None
+
+    @classmethod
+    async def set_timestamp(cls, test_runner: str, timestamp: float) -> None:
+        """Set passed validation timestamp for the given testrunner.
+
+        :param test_runner: test runner container name
+        :type test_runner: str
+        :param timestamp: test runner container name
+        :type timestamp: float
+        :return: none
+        :rtype: NoneType
+        """
+        async with cls.lock:
+            cls.TESTRUNNER_VALIDATION_CACHE[test_runner] = timestamp
+
+    @classmethod
+    async def remove(cls, test_runner: str) -> None:
+        """Remove the given test runner from the validation cache.
+
+        :param test_runner: test runner container name
+        :type test_runner: str
+        :return: none
+        :rtype: NoneType
+        """
+        async with cls.lock:
+            if test_runner in cls.TESTRUNNER_VALIDATION_CACHE:
+                del cls.TESTRUNNER_VALIDATION_CACHE[test_runner]
+
+    @classmethod
+    async def is_test_runner_valid(cls, test_runner: str) -> bool:
+        """Determine if the given test runner is valid.
+
+        :param test_runner: test runner container name
+        :type test_runner: str
+        :return: validation result from cache
+        :rtype: bool
+        """
+        timestamp = await cls.get_timestamp(test_runner)
+        if timestamp is None:
+            return False
+        if (timestamp + cls.TESTRUNNER_VALIDATION_WINDOW) > time.time():
+            return True
+        await cls.remove(test_runner)
+        return False
 
 
 class Environment(BaseModel):
@@ -179,6 +251,7 @@ class SuiteValidator:
         :type test_suite_url: str
         :raises ValidationError: If the suite did not validate.
         """
+        span = trace.get_current_span()
         downloaded_suite = await self._download_suite(test_suite_url)
         assert (
             len(downloaded_suite) > 0
@@ -194,6 +267,24 @@ class SuiteValidator:
                         test_runners.add(constraint.value)
             docker = Docker()
             for test_runner in test_runners:
-                assert (
-                    await docker.digest(test_runner) is not None
-                ), f"Test runner {test_runner} not found"
+                if await TestRunnerValidationCache.is_test_runner_valid(test_runner):
+                    self.logger.info("Using cached test runner validation result: %s", test_runner)
+                    continue
+                for attempt in range(5):
+                    if attempt > 0:
+                        span.add_event(f"Test runner validation unsuccessful, retry #{attempt}")
+                        self.logger.warning(
+                            "Test runner %s validation unsuccessful, retry #%d",
+                            test_runner,
+                            attempt,
+                        )
+                    result = await docker.digest(test_runner)
+                    if result:
+                        # only passed validations shall be cached
+                        await TestRunnerValidationCache.set_timestamp(test_runner, time.time())
+                        break
+                    # Total wait time with 5 attempts: 55 seconds
+                    sleep_time = (attempt + 1) ** 2
+                    await asyncio.sleep(sleep_time)
+
+                assert result is not None, f"Test runner {test_runner} not found"

--- a/python/src/etos_api/library/validator.py
+++ b/python/src/etos_api/library/validator.py
@@ -39,7 +39,7 @@ class TestRunnerValidationCache:
     # Cache for lazy testrunner validation. Keys: container names, values: timestamp.
     # Only passed validations are cached.
     TESTRUNNER_VALIDATION_CACHE = {}
-    TESTRUNNER_VALIDATION_WINDOW = 1800  # seconds
+    TESTRUNNER_VALIDATION_WINDOW = 3600 * 24 * 7  # 1 week
 
     lock = asyncio.Lock()
 


### PR DESCRIPTION
### Applicable Issues

- https://github.com/eiffel-community/etos/issues/286

### Description of the Change

This change restores testrunner validation and cache as they were in version 2.5.2 however with an extended caching time: 1 week instead of 30 minutes.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com