### PR TITLE
Fix the problem where a wrong realm is found in www-authenticate

### DIFF
--- a/python/src/etos_api/library/docker.py
+++ b/python/src/etos_api/library/docker.py
@@ -80,14 +80,16 @@ class Docker:
 
         :param session: Client HTTP session to use for HTTP request.
         :param realm: The realm to authorize against.
-        :type parameters: Parameters to use for the authorization request.
+        :param parameters: Parameters to use for the authorization request.
         :return: Response JSON from authorization request.
         """
         async with session.get(realm, params=parameters) as response:
             response.raise_for_status()
             return await response.json()
 
-    async def authorize(self, session: aiohttp.ClientSession, response: aiohttp.ClientResponse, manifest_url: str) -> str:
+    async def authorize(
+        self, session: aiohttp.ClientSession, response: aiohttp.ClientResponse, manifest_url: str
+    ) -> str:
         """Authorize against container registry.
 
         :param session: Client HTTP session to use for HTTP request.
@@ -112,13 +114,17 @@ class Docker:
             if not isinstance(url, str) or not (
                 url.startswith("http://") or url.startswith("https://")
             ):
-                raise ValueError(f"No realm URL found in www-authenticate header: {response.headers}")
+                raise ValueError(
+                    f"No realm URL found in www-authenticate header: {response.headers}"
+                )
         url = parameters.pop("realm")
         response_json = await self.get_token_from_container_registry(session, url, parameters)
         with self.lock:
             self.tokens[manifest_url] = {
                 "token": response_json.get("token"),
-                "expire": time.time() + response_json.get("expires_in", 0.0) - self.token_expire_modifier,
+                "expire": time.time()
+                + response_json.get("expires_in", 0.0)
+                - self.token_expire_modifier,
             }
         return ""
 
@@ -139,7 +145,6 @@ class Docker:
             key, value = part.split("=")
             parameters[key] = value.strip('"')
         return parameters
-
 
     def tag(self, base: str) -> tuple[str, str]:
         """Figure out tag from a container image name.

--- a/python/src/etos_api/library/docker.py
+++ b/python/src/etos_api/library/docker.py
@@ -16,6 +16,7 @@
 """Docker operations for the ETOS API."""
 import time
 import logging
+from typing import Optional, Mapping
 from threading import Lock
 import aiohttp
 
@@ -33,12 +34,14 @@ class Docker:
     """
 
     logger = logging.getLogger(__name__)
+    # The amount of time in seconds before the token expires where we should recreate it.
+    token_expire_modifier = 30
     # In-memory database for stored authorization tokens.
     # This dictionary shares memory with all instances of `Docker`, by design.
     tokens = {}
     lock = Lock()
 
-    def token(self, manifest_url: str) -> str:
+    def token(self, manifest_url: str) -> Optional[str]:
         """Get a stored token, removing it if expired.
 
         :param manifest_url: URL the token has been stored for.
@@ -54,7 +57,7 @@ class Docker:
             return token.get("token")
 
     async def head(
-        self, session: aiohttp.ClientSession, url: str, token: str = None
+        self, session: aiohttp.ClientSession, url: str, token: Optional[str] = None
     ) -> aiohttp.ClientResponse:
         """Make a HEAD request to a URL, adding token to headers if supplied.
 
@@ -70,36 +73,73 @@ class Docker:
         async with session.head(url, headers=headers) as response:
             return response
 
-    async def authorize(
-        self, session: aiohttp.ClientSession, response: aiohttp.ClientResponse
-    ) -> str:
-        """Get a token from an unauthorized request to image repository.
+    async def get_token_from_container_registry(
+        self, session: aiohttp.ClientSession, realm: str, parameters: dict
+    ) -> dict:
+        """Get a token from an unauthorized request to container repository.
 
         :param session: Client HTTP session to use for HTTP request.
-        :param response: HTTP response to get headers from.
+        :param realm: The realm to authorize against.
+        :type parameters: Parameters to use for the authorization request.
         :return: Response JSON from authorization request.
         """
-        www_auth_header = response.headers.get("www-authenticate")
-        challenge = www_auth_header.replace("Bearer ", "")
-        parts = challenge.split(",")
+        async with session.get(realm, params=parameters) as response:
+            response.raise_for_status()
+            return await response.json()
 
-        url = None
-        query = {}
-        for part in parts:
-            key, value = part.split("=")
-            if key == "realm":
-                url = value.strip('"')
-            else:
-                query[key] = value.strip('"')
+    async def authorize(self, session: aiohttp.ClientSession, response: aiohttp.ClientResponse, manifest_url: str) -> str:
+        """Authorize against container registry.
 
+        :param session: Client HTTP session to use for HTTP request.
+        :param response: Response from a previous request to parse headers from.
+        :param manifest_url: Manifest URL to query should a new auth request be needed.
+        :return: A token retrieved from container registry.
+        """
+        parameters = await self.parse_headers(response.headers)
+        url = parameters.get("realm")
         if not isinstance(url, str) or not (
             url.startswith("http://") or url.startswith("https://")
         ):
-            raise ValueError(f"No realm URL found in www-authenticate header: {www_auth_header}")
+            self.logger.warning("No realm in original request, retrying without a token")
+            with self.lock:
+                try:
+                    del self.tokens[manifest_url]
+                except KeyError:
+                    pass
+            response = await self.head(session, manifest_url)
+            parameters = await self.parse_headers(response.headers)
+            url = parameters.get("realm")
+            if not isinstance(url, str) or not (
+                url.startswith("http://") or url.startswith("https://")
+            ):
+                raise ValueError(f"No realm URL found in www-authenticate header: {response.headers}")
+        url = parameters.pop("realm")
+        response_json = await self.get_token_from_container_registry(session, url, parameters)
+        with self.lock:
+            self.tokens[manifest_url] = {
+                "token": response_json.get("token"),
+                "expire": time.time() + response_json.get("expires_in", 0.0) - self.token_expire_modifier,
+            }
+        return ""
 
-        async with session.get(url, params=query) as response:
-            response.raise_for_status()
-            return await response.json()
+    async def parse_headers(self, headers: Mapping) -> dict:
+        """Parse the www-authenticate header and convert it to a dict.
+
+        :param headers: Headers to parse.
+        :return: Dictionary of the keys in the www-authenticate header.
+        """
+        www_auth_header = headers.get("www-authenticate")
+        if www_auth_header is None:
+            return {}
+        challenge = www_auth_header.replace("Bearer ", "")
+        parts = challenge.split(",")
+
+        parameters = {}
+        for part in parts:
+            key, value = part.split("=")
+            parameters[key] = value.strip('"')
+        return parameters
+
 
     def tag(self, base: str) -> tuple[str, str]:
         """Figure out tag from a container image name.
@@ -149,7 +189,7 @@ class Docker:
             registry = DEFAULT_REGISTRY
         return registry, repo
 
-    async def digest(self, name: str) -> str:
+    async def digest(self, name: str) -> Optional[str]:
         """Get a sha256 digest from an image in an image repository.
 
         :param name: The name of the container image.
@@ -167,13 +207,8 @@ class Docker:
             try:
                 if response.status == 401 and "www-authenticate" in response.headers:
                     self.logger.info("Generate a new authorization token for %r", manifest_url)
-                    response_json = await self.authorize(session, response)
-                    with self.lock:
-                        self.tokens[manifest_url] = {
-                            "token": response_json.get("token"),
-                            "expire": time.time() + response_json.get("expires_in"),
-                        }
-                    response = await self.head(session, manifest_url, self.token(manifest_url))
+                    token = await self.authorize(session, response, manifest_url)
+                    response = await self.head(session, manifest_url, token)
                 digest = response.headers.get("Docker-Content-Digest")
             except aiohttp.ClientResponseError as exception:
                 self.logger.error("Error getting container image %r", exception)


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->
fixes: eiffel-community/etos#286

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
The token cache returned an invalid token for the container registry and when using that token on the first request we got an incorrect realm in the www-authenticate header.
If that happens we will now invalidate the cache and do a HEAD request without a token to get a proper www-authenticate.
I also added an expiration modifier so that we expire the tokens in the cache before they expire on the container registry side.
Added a few variable verifications and type hinting that my editor complained about.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->
We thought about removing the cache entirely but we are not sure if there are rate limits on certain container registries or not and decided to just retry the authentication if it fails.

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->
We will, in some cases, do one more request to the container registry but a single extra request should not happen and this bug does not happen that often.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
