### PR TITLE
Kubernetes provider: include v1alpha+ label when searching for jobs

### DIFF
--- a/deploy/etos-executionspace/Dockerfile
+++ b/deploy/etos-executionspace/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.22-alpine AS build
 WORKDIR /tmp/executionspace
 COPY . .
-RUN apk add --no-cache make=4.4.1-r2 git=2.47.1-r0 && make executionspace
+RUN apk add --no-cache make=4.4.1-r2 git=2.47.2-r0 && make executionspace
 
 FROM alpine:3.17.3
 ARG TZ

--- a/deploy/etos-iut/Dockerfile
+++ b/deploy/etos-iut/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.22-alpine AS build
 WORKDIR /tmp/iut
 COPY . .
-RUN apk add --no-cache make=4.4.1-r2 git=2.47.1-r0 && make iut
+RUN apk add --no-cache make=4.4.1-r2 git=2.47.2-r0 && make iut
 
 FROM alpine:3.17.3
 ARG TZ

--- a/deploy/etos-logarea/Dockerfile
+++ b/deploy/etos-logarea/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.22-alpine AS build
 WORKDIR /tmp/logarea
 COPY . .
-RUN apk add --no-cache make=4.4.1-r2 git=2.47.1-r0 && make logarea
+RUN apk add --no-cache make=4.4.1-r2 git=2.47.2-r0 && make logarea
 
 FROM alpine:3.17.3
 ARG TZ

--- a/deploy/etos-sse/Dockerfile
+++ b/deploy/etos-sse/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.22-alpine AS build
 WORKDIR /tmp/sse
 COPY . .
-RUN apk add --no-cache make=4.4.1-r2 git=2.47.1-r0 && make sse
+RUN apk add --no-cache make=4.4.1-r2 git=2.47.2-r0 && make sse
 
 FROM alpine:3.17.3
 ARG TZ

--- a/internal/executionspace/provider/kubernetes.go
+++ b/internal/executionspace/provider/kubernetes.go
@@ -34,7 +34,7 @@ func (k Kubernetes) New(db database.Opener, cfg config.Config) Provider {
 		providerCore{
 			db:  db,
 			cfg: cfg,
-			url: fmt.Sprintf("%s/v1alpha/executor/kubernetes", cfg.Hostname()),
+			url: fmt.Sprintf("%s/executionspace/v1alpha/executor/kubernetes", cfg.Hostname()),
 			executor: executor.Kubernetes(
 				cfg.ETOSNamespace(),
 			),


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/277

### Description of the Change
This change updates the Kubernetes provider job search with the new label `etos.eiffel-community.github.io/id`. The old label `id` is still kept for backward compatibility.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com