### PR TITLE
Migrate container images to ghcr.io

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -16,13 +16,17 @@ jobs:
     - name: Build app image
       run: docker build . --tag image
 
-    - name: Log into registry
-      run: echo "${{ secrets.REGISTRYPASSWORD }}" | docker login registry.nordix.org -u ${{ secrets.REGISTRYUSERNAME }} --password-stdin
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Push app image
       id: image
       run: |
-        IMAGE_ID=registry.nordix.org/eiffel/etos-api
+        IMAGE_ID=ghcr.io/eiffel-community/etos-api
         # Strip git ref prefix from version
         VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
         # Strip "v" prefix from tag name
@@ -45,13 +49,17 @@ jobs:
     - name: Build app image
       run: docker build . -f deploy/etos-sse/Dockerfile --tag image
 
-    - name: Log into registry
-      run: echo "${{ secrets.REGISTRYPASSWORD }}" | docker login registry.nordix.org -u ${{ secrets.REGISTRYUSERNAME }} --password-stdin
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Push app image
       id: image
       run: |
-        IMAGE_ID=registry.nordix.org/eiffel/etos-sse
+        IMAGE_ID=ghcr.io/eiffel-community/etos-sse
         # Strip git ref prefix from version
         VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
         # Strip "v" prefix from tag name
@@ -74,13 +82,17 @@ jobs:
     - name: Build app image
       run: docker build . -f deploy/etos-logarea/Dockerfile --tag image
 
-    - name: Log into registry
-      run: echo "${{ secrets.REGISTRYPASSWORD }}" | docker login registry.nordix.org -u ${{ secrets.REGISTRYUSERNAME }} --password-stdin
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Push app image
       id: image
       run: |
-        IMAGE_ID=registry.nordix.org/eiffel/etos-logarea
+        IMAGE_ID=ghcr.io/eiffel-community/etos-logarea
         # Strip git ref prefix from version
         VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
         # Strip "v" prefix from tag name
@@ -103,13 +115,17 @@ jobs:
     - name: Build app image
       run: docker build . -f deploy/etos-iut/Dockerfile --tag image
 
-    - name: Log into registry
-      run: echo "${{ secrets.REGISTRYPASSWORD }}" | docker login registry.nordix.org -u ${{ secrets.REGISTRYUSERNAME }} --password-stdin
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Push app image
       id: image
       run: |
-        IMAGE_ID=registry.nordix.org/eiffel/etos-iut
+        IMAGE_ID=ghcr.io/eiffel-community/etos-iut
         # Strip git ref prefix from version
         VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
         # Strip "v" prefix from tag name
@@ -132,13 +148,17 @@ jobs:
     - name: Build app image
       run: docker build . -f deploy/etos-executionspace/Dockerfile --tag image
 
-    - name: Log into registry
-      run: echo "${{ secrets.REGISTRYPASSWORD }}" | docker login registry.nordix.org -u ${{ secrets.REGISTRYUSERNAME }} --password-stdin
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Push app image
       id: image
       run: |
-        IMAGE_ID=registry.nordix.org/eiffel/etos-executionspace
+        IMAGE_ID=ghcr.io/eiffel-community/etos-executionspace
         # Strip git ref prefix from version
         VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
         # Strip "v" prefix from tag name
@@ -165,19 +185,19 @@ jobs:
         changes: |
           {
             "manifests/base/sse/deployment.yaml": {
-              "spec.template.spec.containers[0].image": "registry.nordix.org/eiffel/etos-sse:${{ needs.build_sse.outputs.sseVersion }}"
+              "spec.template.spec.containers[0].image": "ghcr.io/eiffel-community/etos-sse:${{ needs.build_sse.outputs.sseVersion }}"
             },
             "manifests/base/api/deployment.yaml": {
-              "spec.template.spec.containers[0].image": "registry.nordix.org/eiffel/etos-api:${{ needs.build_api.outputs.apiVersion }}"
+              "spec.template.spec.containers[0].image": "ghcr.io/eiffel-community/etos-api:${{ needs.build_api.outputs.apiVersion }}"
             },
             "manifests/base/logarea/deployment.yaml": {
-              "spec.template.spec.containers[0].image": "registry.nordix.org/eiffel/etos-logarea:${{ needs.build_logarea.outputs.logAreaVersion }}"
+              "spec.template.spec.containers[0].image": "ghcr.io/eiffel-community/etos-logarea:${{ needs.build_logarea.outputs.logAreaVersion }}"
             },
             "manifests/base/iut/deployment.yaml": {
-              "spec.template.spec.containers[0].image": "registry.nordix.org/eiffel/etos-iut:${{ needs.build_iut.outputs.iutVersion }}"
+              "spec.template.spec.containers[0].image": "ghcr.io/eiffel-community/etos-iut:${{ needs.build_iut.outputs.iutVersion }}"
             },
             "manifests/base/executionspace/deployment.yaml": {
-              "spec.template.spec.containers[0].image": "registry.nordix.org/eiffel/etos-executionspace:${{ needs.build_executionspace.outputs.executionSpaceVersion }}"
+              "spec.template.spec.containers[0].image": "ghcr.io/eiffel-community/etos-executionspace:${{ needs.build_executionspace.outputs.executionSpaceVersion }}"
             }
           }
         branch: main

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -7,6 +7,10 @@ on:
       - closed
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build_api:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ export GOBUILD := go build
 export PATH := $(GOBIN):$(PATH)
 
 export RELEASE_VERSION ?= $(shell git describe --always)
-export DOCKER_REGISTRY ?= registry.nordix.org
-export DOCKER_NAMESPACE ?= eiffel
+export DOCKER_REGISTRY ?= ghcr.io
+export DOCKER_NAMESPACE ?= eiffel-community
 export DEPLOY ?= etos-sse
 
 PROGRAMS = sse logarea iut executionspace

--- a/manifests/base/api/deployment.yaml
+++ b/manifests/base/api/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: etos-api
       containers:
         - name: etos-api
-          image: registry.nordix.org/eiffel/etos-api:a1acf6b2
+          image: ghcr.io/eiffel-community/etos-api:a1acf6b2
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/manifests/base/executionspace/deployment.yaml
+++ b/manifests/base/executionspace/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: etos-executionspace
       containers:
         - name: etos-executionspace
-          image: registry.nordix.org/eiffel/etos-executionspace:a1acf6b2
+          image: ghcr.io/eiffel-community/etos-executionspace:a1acf6b2
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:

--- a/manifests/base/iut/deployment.yaml
+++ b/manifests/base/iut/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: etos-iut
       containers:
         - name: etos-iut
-          image: registry.nordix.org/eiffel/etos-iut:a1acf6b2
+          image: ghcr.io/eiffel-community/etos-iut:a1acf6b2
           imagePullPolicy: IfNotPresent
           env:
             - name: SERVICE_HOST

--- a/manifests/base/logarea/deployment.yaml
+++ b/manifests/base/logarea/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: etos-logarea
       containers:
         - name: etos-logarea
-          image: registry.nordix.org/eiffel/etos-logarea:a1acf6b2
+          image: ghcr.io/eiffel-community/etos-logarea:a1acf6b2
           imagePullPolicy: IfNotPresent
           env:
             - name: SERVICE_HOST

--- a/manifests/base/sse/deployment.yaml
+++ b/manifests/base/sse/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: etos-sse
       containers:
         - name: etos-sse
-          image: registry.nordix.org/eiffel/etos-sse:a1acf6b2
+          image: ghcr.io/eiffel-community/etos-sse:a1acf6b2
           imagePullPolicy: IfNotPresent
           env:
             - name: SERVICE_HOST


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/343

### Description of the Change
This change migrates ETOS API container images from `nordix.org/eiffel` to `ghcr.io/eiffel-community`.

References to images outside `etos-api` haven't been changed yet.

```
python/src/etos_api/routers/v1alpha/router.py:                    "SUITE_RUNNER_IMAGE", "registry.nordix.org/eiffel/etos-suite-runner:latest"
python/src/etos_api/routers/v1alpha/router.py:                    "LOG_LISTENER_IMAGE", "registry.nordix.org/eiffel/etos-log-listener:latest"
python/src/etos_api/routers/v1alpha/router.py:                    "registry.nordix.org/eiffel/etos-environment-provider:latest",
```

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by:  Andrei Matveyeu, andrei.matveyeu@axis.com