### PR TITLE
Fix for "failed to create PR" in the Github image publishing workflow

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:


### PR DESCRIPTION
### Applicable Issues

### Description of the Change
This change fixes this error in the "Update manifests" step of the Github docker publishing workflow:
```
Run fjogeleit/yaml-update-action@main
Error: failed to create PR: HttpError: Resource not accessible by integration
```

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com