### PR TITLE
SSE: kubernetes.go: fix return of empty job list in getJobsByIdentifier()

### DIFF
--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -72,7 +72,6 @@ func (k *Kubernetes) getJobsByIdentifier(ctx context.Context, client *kubernetes
 	// Try different labels for backward compatibility:
 	// - etos.eiffel-community.github.io/id is v1alpha+
 	// - id is v0 legacy
-	var jobs *v1.JobList
 	for _, label := range []string{"etos.eiffel-community.github.io/id", "id"} {
 		jobs, err := client.BatchV1().Jobs(k.namespace).List(
 			ctx,
@@ -88,7 +87,7 @@ func (k *Kubernetes) getJobsByIdentifier(ctx context.Context, client *kubernetes
 			return jobs, nil
 		}
 	}
-	return jobs, nil
+	return &v1.JobList{Items: []v1.Job{}}, nil
 }
 
 // IsFinished checks if an ESR job is finished.

--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -87,7 +87,7 @@ func (k *Kubernetes) getJobsByIdentifier(ctx context.Context, client *kubernetes
 			return jobs, nil
 		}
 	}
-	return &v1.JobList{Items: []v1.Job{}}, nil
+	return &v1.JobList{}, nil
 }
 
 // IsFinished checks if an ESR job is finished.


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/361

### Description of the Change
This change fixes the return of an empty list in `getJobsByIdentifier()` when no jobs are found.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com