### PR TITLE
library/environment.py: increase etcd lease time

### DIFF
--- a/python/src/etos_api/library/environment.py
+++ b/python/src/etos_api/library/environment.py
@@ -60,7 +60,7 @@ async def configure_testrun(configuration: Configuration, expire: int) -> None:
         testrun.join("provider/iut"),
         expire,
     )
-    await save_json(testrun.join("provider/dataset"), configuration.dataset)
+    await save_json(testrun.join("provider/dataset"), configuration.dataset, expire)
 
 
 async def do_configure(path: ETCDPath, provider_id: str, testrun: ETCDPath, expire: int) -> None:

--- a/python/src/etos_api/library/environment.py
+++ b/python/src/etos_api/library/environment.py
@@ -82,7 +82,7 @@ async def load(path: ETCDPath) -> Optional[dict]:
     return None
 
 
-async def save_json(path: ETCDPath, data: dict, expire=3600) -> None:
+async def save_json(path: ETCDPath, data: dict, expire=86400) -> None:
     """Save data as json to an ETCD path.
 
     :param path: The path to store data on.

--- a/python/src/etos_api/library/environment.py
+++ b/python/src/etos_api/library/environment.py
@@ -33,10 +33,11 @@ class Configuration(BaseModel):
     log_area_provider: str
 
 
-async def configure_testrun(configuration: Configuration) -> None:
+async def configure_testrun(configuration: Configuration, expire: int) -> None:
     """Configure an ETOS testrun with the configuration passed by user.
 
     :param configuration: The configuration to save.
+    :param expire: etcd lease expiration time in seconds
     """
     testrun = ETCDPath(f"/testrun/{configuration.suite_id}")
     providers = ETCDPath("/environment/provider")
@@ -45,30 +46,34 @@ async def configure_testrun(configuration: Configuration) -> None:
         providers.join(f"log-area/{configuration.log_area_provider}"),
         configuration.log_area_provider,
         testrun.join("provider/log-area"),
+        expire,
     )
     await do_configure(
         providers.join(f"execution-space/{configuration.execution_space_provider}"),
         configuration.execution_space_provider,
         testrun.join("provider/execution-space"),
+        expire,
     )
     await do_configure(
         providers.join(f"iut/{configuration.iut_provider}"),
         configuration.iut_provider,
         testrun.join("provider/iut"),
+        expire,
     )
     await save_json(testrun.join("provider/dataset"), configuration.dataset)
 
 
-async def do_configure(path: ETCDPath, provider_id: str, testrun: ETCDPath) -> None:
+async def do_configure(path: ETCDPath, provider_id: str, testrun: ETCDPath, expire: int) -> None:
     """Configure a provider based on provider ID and save it to a testrun.
 
     :param path: Path to load provider from.
     :param provider_id: The ID of the provider to load.
     :param testrun: Where to store the loaded provider.
+    :param expire: etcd lease expiration time in seconds
     """
     if (provider := await load(path)) is None:
         raise AssertionError(f"{provider_id} does not exist")
-    await save_json(testrun, provider)
+    await save_json(testrun, provider, expire)
 
 
 async def load(path: ETCDPath) -> Optional[dict]:
@@ -82,7 +87,7 @@ async def load(path: ETCDPath) -> Optional[dict]:
     return None
 
 
-async def save_json(path: ETCDPath, data: dict, expire=86400) -> None:
+async def save_json(path: ETCDPath, data: dict, expire: int) -> None:
     """Save data as json to an ETCD path.
 
     :param path: The path to store data on.

--- a/python/src/etos_api/routers/v0/router.py
+++ b/python/src/etos_api/routers/v0/router.py
@@ -152,7 +152,7 @@ async def _start(etos: StartEtosRequest, span: Span) -> dict:
         log_area_provider=etos.log_area_provider,
     )
     try:
-        # 10 minutes safety margin for etcd configuration entries
+        # etcd lease expiration will have 10 minutes safety margin:
         etcd_lease_expiration_time = etos_library.debug.default_test_result_timeout + 10 * 60
         await configure_testrun(config, etcd_lease_expiration_time)
     except AssertionError as exception:

--- a/python/src/etos_api/routers/v0/router.py
+++ b/python/src/etos_api/routers/v0/router.py
@@ -152,7 +152,9 @@ async def _start(etos: StartEtosRequest, span: Span) -> dict:
         log_area_provider=etos.log_area_provider,
     )
     try:
-        await configure_testrun(config, etos_library.debug.default_test_result_timeout)
+        # 10 minutes safety margin for etcd configuration entries
+        etcd_lease_expiration_time = etos_library.debug.default_test_result_timeout + 10 * 60
+        await configure_testrun(config, etcd_lease_expiration_time)
     except AssertionError as exception:
         LOGGER.critical(exception)
         raise HTTPException(

--- a/python/src/etos_api/routers/v0/router.py
+++ b/python/src/etos_api/routers/v0/router.py
@@ -152,7 +152,7 @@ async def _start(etos: StartEtosRequest, span: Span) -> dict:
         log_area_provider=etos.log_area_provider,
     )
     try:
-        await configure_testrun(config)
+        await configure_testrun(config, etos_library.debug.default_test_result_timeout)
     except AssertionError as exception:
         LOGGER.critical(exception)
         raise HTTPException(


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/384

### Description of the Change
This change increases the expiration time for etcd entries in `library/environment.py`. This prevents testrun configurations from being automatically deleted when testrun duration exceeds 3600 seconds.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com