### PR TITLE
Catch TimeoutError and return GatewayTimeout to client

### DIFF
--- a/python/src/etos_api/routers/v0/router.py
+++ b/python/src/etos_api/routers/v0/router.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ETOS API router."""
+
 import logging
 import os
 from uuid import uuid4
@@ -115,6 +116,13 @@ async def _start(etos: StartEtosRequest, span: Span) -> dict:
         artifact = await wait_for_artifact_created(
             etos_library, etos.artifact_identity, etos.artifact_id
         )
+    except TimeoutError as error:
+        LOGGER.warning("Timeout error while waiting for artifact.")
+        raise HTTPException(
+            status_code=504,
+            detail=f"Timeout waiting for artifact {etos.artifact_identity or etos.artifact_id}, retry in 30s",
+            headers={"Retry-After": "30"},
+        ) from error
     except Exception as exception:  # pylint:disable=broad-except
         LOGGER.critical(exception)
         raise HTTPException(

--- a/python/src/etos_api/routers/v0/router.py
+++ b/python/src/etos_api/routers/v0/router.py
@@ -93,7 +93,7 @@ async def oldping():
     return RedirectResponse("/api/ping")
 
 
-async def _start(etos: StartEtosRequest, span: Span) -> dict:
+async def _start(etos: StartEtosRequest, span: Span) -> dict:  # pylint:disable=too-many-statements
     """Start ETOS execution.
 
     :param etos: ETOS pydantic model.
@@ -120,7 +120,10 @@ async def _start(etos: StartEtosRequest, span: Span) -> dict:
         LOGGER.warning("Timeout error while waiting for artifact.")
         raise HTTPException(
             status_code=504,
-            detail=f"Timeout waiting for artifact {etos.artifact_identity or etos.artifact_id}, retry in 30s",
+            detail=(
+                f"Timeout waiting for artifact {etos.artifact_identity or etos.artifact_id}, "
+                "retry in 30s"
+            ),
             headers={"Retry-After": "30"},
         ) from error
     except Exception as exception:  # pylint:disable=broad-except

--- a/python/src/etos_api/routers/v1alpha/router.py
+++ b/python/src/etos_api/routers/v1alpha/router.py
@@ -135,7 +135,10 @@ async def _create_testrun(etos: StartTestrunRequest, span: Span) -> dict:
         LOGGER.warning("Timeout error while waiting for artifact.")
         raise HTTPException(
             status_code=504,
-            detail=f"Timeout waiting for artifact {etos.artifact_identity or etos.artifact_id}, retry in 30s",
+            detail=(
+                f"Timeout waiting for artifact {etos.artifact_identity or etos.artifact_id}, "
+                "retry in 30s"
+            ),
             headers={"Retry-After": "30"},
         ) from error
     except Exception as exception:  # pylint:disable=broad-except

--- a/python/src/etos_api/routers/v1alpha/router.py
+++ b/python/src/etos_api/routers/v1alpha/router.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ETOS testrun router."""
+
 import logging
 import os
 from uuid import uuid4
@@ -130,6 +131,13 @@ async def _create_testrun(etos: StartTestrunRequest, span: Span) -> dict:
         artifact = await wait_for_artifact_created(
             etos_library, etos.artifact_identity, etos.artifact_id
         )
+    except TimeoutError as error:
+        LOGGER.warning("Timeout error while waiting for artifact.")
+        raise HTTPException(
+            status_code=504,
+            detail=f"Timeout waiting for artifact {etos.artifact_identity or etos.artifact_id}, retry in 30s",
+            headers={"Retry-After": "30"},
+        ) from error
     except Exception as exception:  # pylint:disable=broad-except
         LOGGER.critical(exception)
         raise HTTPException(


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->
fixes: eiffel-community/etos#388

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
Added a catch for TimeoutError from the GraphQL server and return a retryable error with header telling clients to retry after 30s.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
