### PR TITLE
SSEHandler.Subscribe(): 2s polling interval for h.kube.IsFinished()

### DIFF
--- a/pkg/sse/v1/sse.go
+++ b/pkg/sse/v1/sse.go
@@ -85,7 +85,7 @@ func (h SSEHandler) Subscribe(ch chan<- events.Event, logger *logrus.Entry, ctx 
 	defer close(ch)
 
 	// TODO: Test a streaming approach.
-	tick := time.NewTicker(1 * time.Second)
+	tick := time.NewTicker(2 * time.Second)
 	defer tick.Stop()
 	ping := time.NewTicker(15 * time.Second)
 	defer ping.Stop()


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/423

### Description of the Change
This change increases the polling interval for `h.kube.IsFinished()` in `SSEHandler.Subscribe()`. This is expected to reduce the polling rate of the K8S API polling rate.

### Alternate Designs
- longer polling interval than 2 seconds
- caching layer for K8S API requests
- increased rate limits


### Possible Drawbacks

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com