### PR TITLE
upgrade to Python 3.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.13
       - name: Install Tox
         run: pip install tox
       - name: Upgrade setuptools

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.9-bookworm AS build
+FROM python:3.13-trixie AS build
 
 COPY . /src
 WORKDIR /src/python
-RUN pip install --no-cache-dir build==1.2.2 && python3 -m build
+RUN pip install --no-cache-dir build==1.3.0 && python3 -m build
 
-FROM python:3.9-slim-bookworm
+FROM python:3.13-slim-trixie
 ARG TZ
 ENV TZ=$TZ
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "etos_lib==5.1.3",
+    "etos_lib==5.1.4",
     "etcd3gw~=2.3",
     "uvicorn~=0.22",
     "fastapi~=0.115.6",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License"
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "etos_lib==5.1.3",
     "etcd3gw~=2.3",


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/435

### Description of the Change

This change migrates ETOS API docker and main github workflow to Python 3.13.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com