### PR TITLE
basic artifact identifier validation

### DIFF
--- a/python/src/etos_api/routers/v0/router.py
+++ b/python/src/etos_api/routers/v0/router.py
@@ -30,9 +30,8 @@ from opentelemetry.trace import Span
 
 from etos_api.library.environment import Configuration, configure_testrun
 from etos_api.library.utilities import sync_to_async
-
 from .schemas import AbortEtosResponse, StartEtosRequest, StartEtosResponse
-from .utilities import wait_for_artifact_created, validate_suite
+from .utilities import wait_for_artifact_created, validate_suite, validate_artifact
 
 ETOSv0 = FastAPI(
     title="ETOS",
@@ -107,6 +106,11 @@ async def _start(etos: StartEtosRequest, span: Span) -> dict:  # pylint:disable=
     LOGGER.info("Validating test suite.")
     await validate_suite(etos.test_suite_url)
     LOGGER.info("Test suite validated.")
+
+    # Validate artifact identity and ID before proceeding
+    LOGGER.info("Validating artifact identity and ID.")
+    await validate_artifact(artifact_identity=etos.artifact_identity, artifact_id=etos.artifact_id)
+    LOGGER.info("Artifact identity and ID validated.")
 
     etos_library = ETOS("ETOS API", os.getenv("HOSTNAME"), "ETOS API")
     await sync_to_async(etos_library.config.rabbitmq_publisher_from_environment)

--- a/python/src/etos_api/routers/v1alpha/router.py
+++ b/python/src/etos_api/routers/v1alpha/router.py
@@ -35,12 +35,12 @@ from starlette.responses import Response
 from opentelemetry import trace
 from opentelemetry.trace import Span
 
-
 from .schemas import AbortTestrunResponse, StartTestrunRequest, StartTestrunResponse
 from .utilities import (
     wait_for_artifact_created,
     download_suite,
     validate_suite,
+    validate_artifact,
     convert_to_rfc1123,
     recipes_from_tests,
 )
@@ -123,6 +123,11 @@ async def _create_testrun(etos: StartTestrunRequest, span: Span) -> dict:
     LOGGER.info("Validating test suite.")
     await validate_suite(test_suite)
     LOGGER.info("Test suite validated.")
+
+    # Validate artifact identity and ID before proceeding
+    LOGGER.info("Validating artifact identity and ID.")
+    await validate_artifact(artifact_identity=etos.artifact_identity, artifact_id=etos.artifact_id)
+    LOGGER.info("Artifact identity and ID validated.")
 
     etos_library = ETOS("ETOS API", os.getenv("HOSTNAME", "localhost"), "ETOS API")
 

--- a/python/src/etos_api/routers/v1alpha/utilities.py
+++ b/python/src/etos_api/routers/v1alpha/utilities.py
@@ -28,7 +28,7 @@ from etos_api.library.graphql_queries import (
     ARTIFACT_IDENTITY_QUERY,
     VERIFY_ARTIFACT_ID_EXISTS,
 )
-from etos_api.library.validator import SuiteValidator
+from etos_api.library.validator import SuiteValidator, ArtifactValidator
 
 LOGGER = logging.getLogger(__name__)
 
@@ -134,6 +134,26 @@ def convert_to_rfc1123(value: str) -> str:
     # Replace multiple consecutive hyphens with a single hyphen
     result = re.sub(r"-+", "-", result)
     return result.lower()
+
+
+async def validate_artifact(artifact_identity: str = None, artifact_id=None) -> None:
+    """Validate the artifact identity and ID through the ArtifactValidator.
+
+    :param artifact_identity: The artifact identity to validate (should be PURL if provided).
+    :param artifact_id: The artifact ID to validate (can be UUID object or string).
+    """
+    span = trace.get_current_span()
+
+    try:
+        # Convert artifact_id to string if it's not None
+        artifact_id_str = str(artifact_id) if artifact_id is not None else None
+        ArtifactValidator().validate_artifact_identity_or_id(artifact_identity, artifact_id_str)
+    except ValueError as exception:
+        msg = "Failed to validate artifact identifier"
+        LOGGER.error(msg)
+        LOGGER.error(exception)
+        span.add_event(msg)
+        raise HTTPException(status_code=400, detail=msg) from exception
 
 
 async def recipes_from_tests(tests: list[dict]) -> list[dict]:


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/431

### Description of the Change
This change adds a basic artifact identifier validation making sure the `start` request gets a `400 Bad Request` response if artifact validation fails.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com