### PR TITLE
Pass test_suite_url as suiteSource in TestRun

### DIFF
--- a/python/src/etos_api/routers/v1alpha/router.py
+++ b/python/src/etos_api/routers/v1alpha/router.py
@@ -260,6 +260,7 @@ async def _create_testrun(etos: StartTestrunRequest, span: Span, ctx: otel_conte
                 logArea=etos.log_area_provider,
             ),
             suites=TestRunSpec.from_tercc(test_suite, etos.dataset),
+            suiteSource=etos.test_suite_url,
         ),
     )
 


### PR DESCRIPTION
### Applicable Issues

- https://github.com/eiffel-community/etos/issues/450

### Description of the Change

Store the `test_suite_url` in the new `suiteSource` field when creating the TestRun CRD, so that ESR can use it as `batchesUri` in the TERCC event.

### Alternate Designs

Embed inline `batches` data in the TERCC instead of using `batchesUri`, but that does not scale for large test suites.

### Possible Drawbacks



### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andreimu@axis.com