### PR TITLE
Bump etos_lib from 5.2.1 to 5.3.0

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "etos_lib==5.2.1",
+    "etos_lib==5.3.0",
     "etcd3gw~=2.3",
     "uvicorn~=0.22",
     "fastapi~=0.115.6",


### PR DESCRIPTION
### Applicable Issues

https://github.com/eiffel-community/etos/issues/450

### Description of the Change

Bump etos_lib to 5.3.0 which adds the `suiteSource` field to the `TestRunSpec` schema.

### Alternate Designs



### Possible Drawbacks



### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andreimu@axis.com