### PR TITLE
Update GitHub Actions for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Build app image
       run: docker build . --tag image
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -56,7 +56,7 @@ jobs:
     - name: Build app image
       run: docker build . -f deploy/etos-sse/Dockerfile --tag image
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -90,7 +90,7 @@ jobs:
     - name: Build app image
       run: docker build . -f deploy/etos-keys/Dockerfile --tag image
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -124,7 +124,7 @@ jobs:
     - name: Build app image
       run: docker build . -f deploy/etos-logarea/Dockerfile --tag image
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -158,7 +158,7 @@ jobs:
     - name: Build app image
       run: docker build . -f deploy/etos-iut/Dockerfile --tag image
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -192,7 +192,7 @@ jobs:
     - name: Build app image
       run: docker build . -f deploy/etos-executionspace/Dockerfile --tag image
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,10 +16,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under , so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: 3.13
       - name: Install Tox
@@ -37,9 +37,9 @@ jobs:
         # Since we have 1.21 in the go.mod file, but toolchain is go1.22.1
         go-version: [ '1.21', '1.22.1' ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
       - name: Go test
@@ -52,22 +52,22 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under , so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Run hadolint for API
-        uses: hadolint/hadolint-action@master
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: Dockerfile
       - name: Run hadolint for SSE
-        uses: hadolint/hadolint-action@master
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: deploy/etos-sse/Dockerfile
       - name: Run hadolint for KeyService
-        uses: hadolint/hadolint-action@master
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: deploy/etos-keys/Dockerfile
       - name: Run hadolint for LogArea
-        uses: hadolint/hadolint-action@master
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: deploy/etos-logarea/Dockerfile
 
@@ -79,25 +79,25 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under , so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Build API image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
       - name: Build SSE image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./deploy/etos-sse/Dockerfile
       - name: Build KeyService image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./deploy/etos-keys/Dockerfile
       - name: Build LogArea image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./deploy/etos-logarea/Dockerfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         # Since we have 1.21 in the go.mod file, but toolchain is go1.22.1
-        go-version: [ '1.21', '1.22.1' ]
+        go-version: [ '1.22.1' ]
     steps:
       - uses: actions/checkout@v6
       - name: Setup Go ${{ matrix.go-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Since we have 1.21 in the go.mod file, but toolchain is go1.22.1
         go-version: [ '1.22.1' ]
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/update-etos.yaml
+++ b/.github/workflows/update-etos.yaml
@@ -56,7 +56,7 @@ jobs:
         } >> "$GITHUB_ENV"
     - name: Generate a token
       id: generate-token
-      uses: actions/create-github-app-token@v2
+      uses: actions/create-github-app-token@v3
       with:
         owner: ${{ env.REPOSITORY_OWNER }}
         repositories: ${{ env.ETOS_REPOSITORY }}
@@ -67,7 +67,7 @@ jobs:
         repository: ${{ env.REPOSITORY_OWNER }}/${{ env.ETOS_REPOSITORY }}
         token: ${{ steps.generate-token.outputs.token }}
     - name: Update manifests
-      uses: fjogeleit/yaml-update-action@main
+      uses: fjogeleit/yaml-update-action@v0.16.1
       with:
         commitChange: false
         token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
### Applicable Issues

https://github.com/eiffel-community/etos/issues/595

### Description of the Change

Update 3 workflow files: checkout v2/v4→v6, setup-python v2→v6, setup-go v5→v6, docker/login-action v3→v4, create-github-app-token v2→v3, and fjogeleit/yaml-update-action main→v0.16.1.

### Alternate Designs

_No response_

### Possible Drawbacks

Note: `fjogeleit/yaml-update-action` is pinned to v0.16.1 (still node20) as no node24-compatible release exists yet.

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com