### PR TITLE
Add a retry when connecting to RabbitMQ messagebus

### DIFF
--- a/cmd/sse/main.go
+++ b/cmd/sse/main.go
@@ -79,7 +79,7 @@ func main() {
 			log.Fatal("ETOS_RABBITMQ_STREAM_NAME must be set for the SSE server to work.")
 		}
 		log.Infof("Starting up a RabbitMQStreamer with stream name: %s", cfg.RabbitMQStreamName())
-		streamer, err = stream.NewRabbitMQStreamer(*rabbitMQStream.NewEnvironmentOptions().SetUri(cfg.RabbitMQURI()), log, cfg.RabbitMQStreamName())
+		streamer, err = stream.NewRabbitMQStreamer(ctx, *rabbitMQStream.NewEnvironmentOptions().SetUri(cfg.RabbitMQURI()), log, cfg.RabbitMQStreamName())
 		if err != nil {
 			log.Fatal(err.Error())
 		}

--- a/internal/stream/rabbitmq.go
+++ b/internal/stream/rabbitmq.go
@@ -45,7 +45,7 @@ type RabbitMQStreamer struct {
 func NewRabbitMQStreamer(ctx context.Context, options stream.EnvironmentOptions, logger *logrus.Entry, streamName string) (Streamer, error) {
 	var err error
 	var env *stream.Environment
-	if err := retry.Do(ctx, retry.WithMaxRetries(maxRetries, retry.NewConstant(retryDelay)), func(ctx context.Context) error {
+	if err = retry.Do(ctx, retry.WithMaxRetries(maxRetries, retry.NewConstant(retryDelay)), func(ctx context.Context) error {
 		env, err = stream.NewEnvironment(&options)
 		if err != nil {
 			logger.WithError(err).Warning("failed to connect to RabbitMQ, retrying...")
@@ -53,7 +53,7 @@ func NewRabbitMQStreamer(ctx context.Context, options stream.EnvironmentOptions,
 		}
 		return nil
 	}); err != nil {
-		return nil, fmt.Errorf("failed to connect to RabbitMQ after %d attempts: %w", maxRetries, err)
+		return nil, fmt.Errorf("failed to connect to RabbitMQ after %d retries: %w", maxRetries, err)
 	}
 	return &RabbitMQStreamer{environment: env, logger: logger, streamName: streamName}, err
 }

--- a/internal/stream/rabbitmq.go
+++ b/internal/stream/rabbitmq.go
@@ -48,7 +48,7 @@ func NewRabbitMQStreamer(ctx context.Context, options stream.EnvironmentOptions,
 	if err := retry.Do(ctx, retry.WithMaxRetries(maxRetries, retry.NewConstant(retryDelay)), func(ctx context.Context) error {
 		env, err = stream.NewEnvironment(&options)
 		if err != nil {
-			logger.WithError(err).Error("failed to connect to RabbitMQ, retrying...")
+			logger.WithError(err).Warning("failed to connect to RabbitMQ, retrying...")
 			return retry.RetryableError(err)
 		}
 		return nil

--- a/internal/stream/rabbitmq.go
+++ b/internal/stream/rabbitmq.go
@@ -24,10 +24,13 @@ import (
 
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/amqp"
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream"
+	"github.com/sethvargo/go-retry"
 	"github.com/sirupsen/logrus"
 )
 
 const IgnoreUnfiltered = false
+const maxRetries = 10
+const retryDelay = 5 * time.Second
 
 // RabbitMQStreamer is a struct representing a single RabbitMQ connection. From a new connection new streams may be created.
 // Normal case is to have a single connection with multiple streams. If multiple connections are needed then multiple
@@ -39,10 +42,18 @@ type RabbitMQStreamer struct {
 }
 
 // NewRabbitMQStreamer creates a new RabbitMQ streamer. Only a single connection should be created.
-func NewRabbitMQStreamer(options stream.EnvironmentOptions, logger *logrus.Entry, streamName string) (Streamer, error) {
-	env, err := stream.NewEnvironment(&options)
-	if err != nil {
-		return nil, err
+func NewRabbitMQStreamer(ctx context.Context, options stream.EnvironmentOptions, logger *logrus.Entry, streamName string) (Streamer, error) {
+	var err error
+	var env *stream.Environment
+	if err := retry.Do(ctx, retry.WithMaxRetries(maxRetries, retry.NewConstant(retryDelay)), func(ctx context.Context) error {
+		env, err = stream.NewEnvironment(&options)
+		if err != nil {
+			logger.WithError(err).Error("failed to connect to RabbitMQ, retrying...")
+			return retry.RetryableError(err)
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to connect to RabbitMQ after %d attempts: %w", maxRetries, err)
 	}
 	return &RabbitMQStreamer{environment: env, logger: logger, streamName: streamName}, err
 }

--- a/python/tests/fake_database.py
+++ b/python/tests/fake_database.py
@@ -19,6 +19,7 @@ from queue import Queue
 from threading import Event, RLock, Timer
 from typing import Any, Iterator, Optional
 
+from etcd3gw import Etcd3Client as EtcdClient
 from etcd3gw.lease import Lease
 
 # pylint:disable=unused-argument
@@ -87,7 +88,7 @@ class FakeDatabase:
         # ttl is unused since we do not actually make the post request that the regular
         # etcd client does. First argument to `Lease` is the ID that was returned by the
         # etcd server.
-        return Lease(len(self.expire) - 1)
+        return Lease(len(self.expire) - 1, EtcdClient())
 
     def get(self, path: str) -> list[bytes]:
         """Get an item from database."""


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->
eiffel-community/etos#601
#104 

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
Add a retry when connecting. With the implementation in #104 we will get intermittent failures of the e2e tests due to the messagebus not always starting up before the SSE server.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
