### PR TITLE
Update Go from 1.22 to 1.26

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.22.1' ]
+        go-version: [ '1.25' ]
     steps:
       - uses: actions/checkout@v6
       - name: Setup Go ${{ matrix.go-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.25' ]
+        go-version: [ '1.26' ]
     steps:
       - uses: actions/checkout@v6
       - name: Setup Go ${{ matrix.go-version }}

--- a/deploy/etos-executionspace/Dockerfile
+++ b/deploy/etos-executionspace/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /tmp/executionspace
 
 # Cache dependencies early

--- a/deploy/etos-executionspace/Dockerfile
+++ b/deploy/etos-executionspace/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.22-alpine AS build
+FROM golang:1.25-alpine AS build
 WORKDIR /tmp/executionspace
 
 # Cache dependencies early
-RUN apk add --no-cache make=4.4.1-r2 git=2.47.3-r0
+RUN apk add --no-cache make=4.4.1-r3 git=2.52.0-r0
 COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download

--- a/deploy/etos-executionspace/Dockerfile.dev
+++ b/deploy/etos-executionspace/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.22
+FROM golang:1.25
 WORKDIR /app
 
 COPY ./go.mod ./go.sum ./

--- a/deploy/etos-executionspace/Dockerfile.dev
+++ b/deploy/etos-executionspace/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.25
+FROM golang:1.26
 WORKDIR /app
 
 COPY ./go.mod ./go.sum ./

--- a/deploy/etos-iut/Dockerfile
+++ b/deploy/etos-iut/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.22-alpine AS build
+FROM golang:1.25-alpine AS build
 WORKDIR /tmp/iut
 
 # Cache dependencies early
-RUN apk add --no-cache make=4.4.1-r2 git=2.47.3-r0
+RUN apk add --no-cache make=4.4.1-r3 git=2.52.0-r0
 COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download

--- a/deploy/etos-iut/Dockerfile
+++ b/deploy/etos-iut/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /tmp/iut
 
 # Cache dependencies early

--- a/deploy/etos-iut/Dockerfile.dev
+++ b/deploy/etos-iut/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.22
+FROM golang:1.25
 WORKDIR /app
 
 COPY ./go.mod ./go.sum ./

--- a/deploy/etos-iut/Dockerfile.dev
+++ b/deploy/etos-iut/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.25
+FROM golang:1.26
 WORKDIR /app
 
 COPY ./go.mod ./go.sum ./

--- a/deploy/etos-keys/Dockerfile
+++ b/deploy/etos-keys/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.22-alpine AS build
+FROM golang:1.25-alpine AS build
 WORKDIR /tmp/keys
 
 # Cache dependencies early
-RUN apk add --no-cache make=4.4.1-r2 git=2.47.3-r0
+RUN apk add --no-cache make=4.4.1-r3 git=2.52.0-r0
 COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download

--- a/deploy/etos-keys/Dockerfile
+++ b/deploy/etos-keys/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /tmp/keys
 
 # Cache dependencies early

--- a/deploy/etos-keys/Dockerfile.dev
+++ b/deploy/etos-keys/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.22
+FROM golang:1.25
 WORKDIR /app
 
 COPY ./go.mod ./go.sum ./

--- a/deploy/etos-keys/Dockerfile.dev
+++ b/deploy/etos-keys/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.25
+FROM golang:1.26
 WORKDIR /app
 
 COPY ./go.mod ./go.sum ./

--- a/deploy/etos-logarea/Dockerfile
+++ b/deploy/etos-logarea/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.22-alpine AS build
+FROM golang:1.25-alpine AS build
 WORKDIR /tmp/logarea
 
 # Cache dependencies early
-RUN apk add --no-cache make=4.4.1-r2 git=2.47.3-r0
+RUN apk add --no-cache make=4.4.1-r3 git=2.52.0-r0
 COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download

--- a/deploy/etos-logarea/Dockerfile
+++ b/deploy/etos-logarea/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /tmp/logarea
 
 # Cache dependencies early

--- a/deploy/etos-logarea/Dockerfile.dev
+++ b/deploy/etos-logarea/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.22
+FROM golang:1.25
 WORKDIR /app
 
 COPY ./go.mod ./go.sum ./

--- a/deploy/etos-logarea/Dockerfile.dev
+++ b/deploy/etos-logarea/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.25
+FROM golang:1.26
 WORKDIR /app
 
 COPY ./go.mod ./go.sum ./

--- a/deploy/etos-sse/Dockerfile
+++ b/deploy/etos-sse/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /tmp/sse
 
 # Cache dependencies early

--- a/deploy/etos-sse/Dockerfile
+++ b/deploy/etos-sse/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.22-alpine AS build
+FROM golang:1.25-alpine AS build
 WORKDIR /tmp/sse
 
 # Cache dependencies early
-RUN apk add --no-cache make=4.4.1-r2 git=2.47.3-r0
+RUN apk add --no-cache make=4.4.1-r3 git=2.52.0-r0
 COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download

--- a/deploy/etos-sse/Dockerfile.dev
+++ b/deploy/etos-sse/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.22
+FROM golang:1.25
 WORKDIR /app
 
 COPY ./go.mod ./go.sum ./

--- a/deploy/etos-sse/Dockerfile.dev
+++ b/deploy/etos-sse/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.25
+FROM golang:1.26
 WORKDIR /app
 
 COPY ./go.mod ./go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/eiffel-community/etos-api
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/eiffel-community/eiffelevents-sdk-go v0.0.0-20240807115026-5ca5c194b7dc

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/eiffel-community/etos-api
 
-go 1.22.0
-
-toolchain go1.22.1
+go 1.25.0
 
 require (
 	github.com/eiffel-community/eiffelevents-sdk-go v0.0.0-20240807115026-5ca5c194b7dc


### PR DESCRIPTION
### Applicable Issues

https://github.com/eiffel-community/etos/issues/615

### Description of the Change

Update Go from 1.22 (EOL) to 1.26 in go.mod, Dockerfiles, and CI workflow.

### Alternate Designs



### Possible Drawbacks



### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andreimu@axis.com