### PR TITLE
Set TLS ServerName for RabbitMQ stream connections

### DIFF
--- a/cmd/sse/main.go
+++ b/cmd/sse/main.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"crypto/tls"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"runtime/debug"
@@ -83,7 +84,11 @@ func main() {
 		log.Infof("Starting up a RabbitMQStreamer with stream name: %s", cfg.RabbitMQStreamName())
 		opts := rabbitMQStream.NewEnvironmentOptions().SetUri(cfg.RabbitMQURI())
 		if strings.HasPrefix(cfg.RabbitMQURI(), "rabbitmq-stream+tls://") {
-			opts = opts.SetTLSConfig(&tls.Config{})
+			var serverName string
+			if u, err := url.Parse(cfg.RabbitMQURI()); err == nil {
+				serverName = u.Hostname()
+			}
+			opts = opts.SetTLSConfig(&tls.Config{ServerName: serverName})
 		}
 		streamer, err = stream.NewRabbitMQStreamer(ctx, *opts, log, cfg.RabbitMQStreamName())
 		if err != nil {


### PR DESCRIPTION
### Applicable Issues



### Description of the Change

Set `ServerName` in `tls.Config` when connecting to RabbitMQ streams over TLS, fixing a handshake failure caused by an empty TLS config.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com