### PR TITLE
Fix SSE returning 404 for testruns still provisioning

### DIFF
--- a/internal/kubernetes/kubernetes.go
+++ b/internal/kubernetes/kubernetes.go
@@ -280,28 +280,51 @@ func keyPairExists(labels map[string]string, keyPair map[string]string) bool {
 	return true
 }
 
+// JobStatus represents the status of a suite-runner job.
+type JobStatus int
+
+const (
+	// JobRunning indicates the job exists and is still running.
+	JobRunning JobStatus = iota
+	// JobFinished indicates the job exists and has completed (succeeded or failed).
+	JobFinished
+	// JobNotFound indicates no matching job was found in the cluster.
+	// This can mean the job has not been created yet (testrun is still
+	// provisioning) or that it was already cleaned up after completion.
+	JobNotFound
+)
+
 // IsFinished checks if an ESR job is finished.
+// Deprecated: Use JobState instead, which distinguishes "not found" from "finished".
 func (k *Kubernetes) IsFinished(ctx context.Context, identifier string) bool {
+	state := k.JobState(ctx, identifier)
+	// Preserve legacy behavior: treat not-found as finished.
+	return state == JobFinished || state == JobNotFound
+}
+
+// JobState returns the status of the suite-runner job for the given identifier.
+// Unlike IsFinished, it distinguishes between a job that has not been created yet
+// (JobNotFound) and one that has completed (JobFinished).
+func (k *Kubernetes) JobState(ctx context.Context, identifier string) JobStatus {
 	client, err := k.clientset()
 	if err != nil {
 		k.logger.Error(err)
-		return false
+		return JobRunning
 	}
 	jobs, err := k.getJobsByIdentifier(ctx, client, identifier)
 	if err != nil {
 		k.logger.Error(err)
-		return false
+		return JobRunning
 	}
 	if len(jobs.Items) == 0 {
-		// Assume that a job is finished if it does not exist.
-		k.logger.Warningf("job with id %s does not exist, assuming finished", identifier)
-		return true
+		k.logger.Warningf("job with id %s does not exist", identifier)
+		return JobNotFound
 	}
 	job := jobs.Items[0]
 	if job.Status.Succeeded == 0 && job.Status.Failed == 0 {
-		return false
+		return JobRunning
 	}
-	return true
+	return JobFinished
 }
 
 // LogListenerIP gets the IP address of an ESR log listener.

--- a/pkg/sse/v1/sse.go
+++ b/pkg/sse/v1/sse.go
@@ -100,11 +100,12 @@ func (h SSEHandler) Subscribe(ch chan<- events.Event, logger *logrus.Entry, ctx 
 		case <-tick.C:
 			newEvents, err := GetFrom(ctx, url, fmt.Sprint(counter))
 			if err != nil {
-				// The context sent to IsFinished may be canceled due to client-side
-				// throttling by Kubernetes. We don't want IsFinished to cancel the
+				// The context sent to JobState may be canceled due to client-side
+				// throttling by Kubernetes. We don't want JobState to cancel the
 				// the request context from our clients, causing a ConnectionReset,
 				// so we create a new context here.
-				if h.kube.IsFinished(context.Background(), identifier) {
+				state := h.kube.JobState(context.Background(), identifier)
+				if state == kubernetes.JobFinished || state == kubernetes.JobNotFound {
 					logger.Info("ESR finished, shutting down")
 					// If the shutdown event is not sent to the client, then the client will
 					// reconnect and the message will be received next time.
@@ -195,7 +196,8 @@ func (h SSEHandler) url(ctx context.Context, identifier string) (string, error) 
 func (h SSEHandler) GetEvent(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	identifier := ps.ByName("identifier")
 	counter := ps.ByName("id")
-	if h.kube.IsFinished(r.Context(), identifier) {
+	state := h.kube.JobState(r.Context(), identifier)
+	if state == kubernetes.JobFinished {
 		http.NotFound(w, r)
 		return
 	}
@@ -204,6 +206,11 @@ func (h SSEHandler) GetEvent(w http.ResponseWriter, r *http.Request, ps httprout
 
 	url, err := h.url(r.Context(), identifier)
 	if err != nil {
+		if state == kubernetes.JobNotFound {
+			logger.Info("Suite runner not yet available, returning 503")
+			http.Error(w, "Suite runner not yet available", http.StatusServiceUnavailable)
+			return
+		}
 		logger.Error(err)
 		http.NotFound(w, r)
 		return
@@ -223,7 +230,8 @@ func (h SSEHandler) GetEvent(w http.ResponseWriter, r *http.Request, ps httprout
 // GetEvents is an endpoint for streaming events and logs from an ESR instance.
 func (h SSEHandler) GetEvents(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	identifier := ps.ByName("identifier")
-	if h.kube.IsFinished(r.Context(), identifier) {
+	state := h.kube.JobState(r.Context(), identifier)
+	if state == kubernetes.JobFinished {
 		http.NotFound(w, r)
 		return
 	}
@@ -232,6 +240,11 @@ func (h SSEHandler) GetEvents(w http.ResponseWriter, r *http.Request, ps httprou
 
 	url, err := h.url(r.Context(), identifier)
 	if err != nil {
+		if state == kubernetes.JobNotFound {
+			logger.Info("Suite runner not yet available, returning 503")
+			http.Error(w, "Suite runner not yet available", http.StatusServiceUnavailable)
+			return
+		}
 		http.NotFound(w, r)
 		return
 	}

--- a/pkg/sse/v1alpha/sse.go
+++ b/pkg/sse/v1alpha/sse.go
@@ -100,11 +100,12 @@ func (h SSEHandler) Subscribe(ch chan<- events.Event, logger *logrus.Entry, ctx 
 		case <-tick.C:
 			messages, err := GetFrom(ctx, url)
 			if err != nil {
-				// The context sent to IsFinished may be canceled due to client-side
-				// throttling by Kubernetes. We don't want IsFinished to cancel the
+				// The context sent to JobState may be canceled due to client-side
+				// throttling by Kubernetes. We don't want JobState to cancel the
 				// the request context from our clients, causing a ConnectionReset,
 				// so we create a new context here.
-				if h.kube.IsFinished(context.Background(), identifier) {
+				state := h.kube.JobState(context.Background(), identifier)
+				if state == kubernetes.JobFinished || state == kubernetes.JobNotFound {
 					logger.Info("ESR finished, shutting down")
 					ch <- events.Event{Event: "shutdown"}
 					return
@@ -182,7 +183,8 @@ func forceKillConnection(w http.ResponseWriter, logger *logrus.Entry) {
 // GetEvents is an endpoint for streaming events and logs from an ESR instance.
 func (h SSEHandler) GetEvents(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	identifier := ps.ByName("identifier")
-	if h.kube.IsFinished(r.Context(), identifier) {
+	state := h.kube.JobState(r.Context(), identifier)
+	if state == kubernetes.JobFinished {
 		http.NotFound(w, r)
 		return
 	}
@@ -191,6 +193,11 @@ func (h SSEHandler) GetEvents(w http.ResponseWriter, r *http.Request, ps httprou
 
 	url, err := h.url(r.Context(), identifier)
 	if err != nil {
+		if state == kubernetes.JobNotFound {
+			logger.Info("Suite runner not yet available, returning 503")
+			http.Error(w, "Suite runner not yet available", http.StatusServiceUnavailable)
+			return
+		}
 		http.NotFound(w, r)
 		return
 	}


### PR DESCRIPTION
### Applicable Issues

Fixes https://github.com/eiffel-community/etos/issues/625

### Description of the Change

When no suite-runner job exists yet (e.g. during environment provisioning), `IsFinished()` returns `true` because it conflates "job not found" with "job finished." This causes the SSE server to return 404, which is semantically incorrect for a resource that will exist once provisioning completes.

This change introduces a tri-state `JobState()` method that distinguishes `JobRunning`, `JobFinished`, and `JobNotFound`. The SSE handlers now return 503 (Service Unavailable) instead of 404 when the job has not been created yet.

### Alternate Designs

_None_

### Possible Drawbacks

_None_

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com