### PR TITLE
Update Alpine base image from 3.17.3 to 3.23.4

### DIFF
--- a/deploy/etos-executionspace/Dockerfile
+++ b/deploy/etos-executionspace/Dockerfile
@@ -18,7 +18,7 @@ COPY .git/ .git/
 
 RUN make executionspace
 
-FROM alpine:3.17.3
+FROM alpine:3.23.4
 ARG TZ
 ENV TZ=$TZ
 
@@ -26,7 +26,7 @@ LABEL org.opencontainers.image.source=https://github.com/eiffel-community/etos-a
 LABEL org.opencontainers.image.authors=etos-maintainers@googlegroups.com
 LABEL org.opencontainers.image.licenses=Apache-2.0
 
-RUN apk add --no-cache tzdata=2024a-r0
+RUN apk add --no-cache tzdata=2026a-r0
 ENTRYPOINT ["/app/executionspace"]
 
 COPY --from=build /tmp/executionspace/bin/executionspace /app/executionspace

--- a/deploy/etos-iut/Dockerfile
+++ b/deploy/etos-iut/Dockerfile
@@ -18,7 +18,7 @@ COPY .git/ .git/
 
 RUN make iut
 
-FROM alpine:3.17.3
+FROM alpine:3.23.4
 ARG TZ
 ENV TZ=$TZ
 
@@ -26,7 +26,7 @@ LABEL org.opencontainers.image.source=https://github.com/eiffel-community/etos-a
 LABEL org.opencontainers.image.authors=etos-maintainers@googlegroups.com
 LABEL org.opencontainers.image.licenses=Apache-2.0
 
-RUN apk add --no-cache tzdata=2024a-r0
+RUN apk add --no-cache tzdata=2026a-r0
 ENTRYPOINT ["/app/iut"]
 
 COPY --from=build /tmp/iut/bin/iut /app/iut

--- a/deploy/etos-keys/Dockerfile
+++ b/deploy/etos-keys/Dockerfile
@@ -18,7 +18,7 @@ COPY .git/ .git/
 
 RUN make keys
 
-FROM alpine:3.17.3
+FROM alpine:3.23.4
 ARG TZ
 ENV TZ=$TZ
 
@@ -26,7 +26,7 @@ LABEL org.opencontainers.image.source=https://github.com/eiffel-community/etos-a
 LABEL org.opencontainers.image.authors=etos-maintainers@googlegroups.com
 LABEL org.opencontainers.image.licenses=Apache-2.0
 
-RUN apk add --no-cache tzdata=2024a-r0
+RUN apk add --no-cache tzdata=2026a-r0
 ENTRYPOINT ["/app/keys"]
 
 COPY --from=build /tmp/keys/bin/keys /app/keys

--- a/deploy/etos-logarea/Dockerfile
+++ b/deploy/etos-logarea/Dockerfile
@@ -18,7 +18,7 @@ COPY .git/ .git/
 
 RUN make logarea
 
-FROM alpine:3.17.3
+FROM alpine:3.23.4
 ARG TZ
 ENV TZ=$TZ
 
@@ -26,7 +26,7 @@ LABEL org.opencontainers.image.source=https://github.com/eiffel-community/etos-a
 LABEL org.opencontainers.image.authors=etos-maintainers@googlegroups.com
 LABEL org.opencontainers.image.licenses=Apache-2.0
 
-RUN apk add --no-cache tzdata=2024a-r0
+RUN apk add --no-cache tzdata=2026a-r0
 ENTRYPOINT ["/app/logarea"]
 
 COPY --from=build /tmp/logarea/bin/logarea /app/logarea

--- a/deploy/etos-sse/Dockerfile
+++ b/deploy/etos-sse/Dockerfile
@@ -18,7 +18,7 @@ COPY .git/ .git/
 
 RUN make sse
 
-FROM alpine:3.17.3
+FROM alpine:3.23.4
 ARG TZ
 ENV TZ=$TZ
 
@@ -26,7 +26,7 @@ LABEL org.opencontainers.image.source=https://github.com/eiffel-community/etos-a
 LABEL org.opencontainers.image.authors=etos-maintainers@googlegroups.com
 LABEL org.opencontainers.image.licenses=Apache-2.0
 
-RUN apk add --no-cache tzdata=2024a-r0
+RUN apk add --no-cache tzdata=2026a-r0
 ENTRYPOINT ["/app/sse"]
 
 COPY --from=build /tmp/sse/bin/sse /app/sse


### PR DESCRIPTION
### Applicable Issues

### Description of the Change

Update the Alpine Linux base image in all Go service Dockerfiles (etos-sse, etos-logarea, etos-keys, etos-executionspace, etos-iut) from 3.17.3 to 3.23.4. Also updates the pinned tzdata package version from 2024a-r0 to 2026a-r0 to match the new Alpine release.

Alpine 3.17 has reached end of life and no longer receives security patches.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com