### PR TITLE
Improve identity validation error messages

### DIFF
--- a/python/src/etos_api/routers/v0/schemas.py
+++ b/python/src/etos_api/routers/v0/schemas.py
@@ -62,9 +62,13 @@ class StartEtosRequest(EtosRequest):
         values = info.data
         artifact_identity = values.get("artifact_identity")
 
+        # Treat empty/whitespace-only identity as not provided
+        if isinstance(artifact_identity, str) and not artifact_identity.strip():
+            artifact_identity = None
+
         # Check that at least one is provided
         if artifact_identity is None and not artifact_id:
-            raise ValueError("At least one of 'artifact_identity' or 'artifact_id' is required.")
+            raise ValueError("Missing or invalid identity: provide a valid UUID or PURL.")
 
         # Check that only one is provided
         if artifact_identity is not None and artifact_id:
@@ -73,7 +77,7 @@ class StartEtosRequest(EtosRequest):
         # Validate artifact_identity format if provided
         if artifact_identity is not None:
             if not isinstance(artifact_identity, str) or not artifact_identity.startswith("pkg:"):
-                raise ValueError("artifact_identity must be a string starting with 'pkg:'")
+                raise ValueError("Invalid artifact_identity: must be a valid PURL.")
 
         # Note: artifact_id UUID validation is handled by Pydantic's built-in UUID type validation
 

--- a/python/src/etos_api/routers/v0/schemas.py
+++ b/python/src/etos_api/routers/v0/schemas.py
@@ -68,7 +68,7 @@ class StartEtosRequest(EtosRequest):
 
         # Check that at least one is provided
         if artifact_identity is None and not artifact_id:
-            raise ValueError("Missing or invalid identity: provide a valid UUID or PURL.")
+            raise ValueError("Missing or invalid identity: provide a valid UUID or PackageURL.")
 
         # Check that only one is provided
         if artifact_identity is not None and artifact_id:
@@ -77,7 +77,7 @@ class StartEtosRequest(EtosRequest):
         # Validate artifact_identity format if provided
         if artifact_identity is not None:
             if not isinstance(artifact_identity, str) or not artifact_identity.startswith("pkg:"):
-                raise ValueError("Invalid artifact_identity: must be a valid PURL.")
+                raise ValueError("Invalid artifact_identity: must be a valid PackageURL.")
 
         # Note: artifact_id UUID validation is handled by Pydantic's built-in UUID type validation
 

--- a/python/src/etos_api/routers/v1alpha/schemas.py
+++ b/python/src/etos_api/routers/v1alpha/schemas.py
@@ -61,9 +61,13 @@ class StartTestrunRequest(TestrunRequest):
         values = info.data
         artifact_identity = values.get("artifact_identity")
 
+        # Treat empty/whitespace-only identity as not provided
+        if isinstance(artifact_identity, str) and not artifact_identity.strip():
+            artifact_identity = None
+
         # Check that at least one is provided
         if artifact_identity is None and not artifact_id:
-            raise ValueError("At least one of 'artifact_identity' or 'artifact_id' is required.")
+            raise ValueError("Missing or invalid identity: provide a valid UUID or PURL.")
 
         # Check that only one is provided
         if artifact_identity is not None and artifact_id:
@@ -72,7 +76,7 @@ class StartTestrunRequest(TestrunRequest):
         # Validate artifact_identity format if provided
         if artifact_identity is not None:
             if not isinstance(artifact_identity, str) or not artifact_identity.startswith("pkg:"):
-                raise ValueError("artifact_identity must be a string starting with 'pkg:'")
+                raise ValueError("Invalid artifact_identity: must be a valid PURL.")
 
         # Note: artifact_id UUID validation is handled by Pydantic's built-in UUID type validation
 

--- a/python/src/etos_api/routers/v1alpha/schemas.py
+++ b/python/src/etos_api/routers/v1alpha/schemas.py
@@ -67,7 +67,7 @@ class StartTestrunRequest(TestrunRequest):
 
         # Check that at least one is provided
         if artifact_identity is None and not artifact_id:
-            raise ValueError("Missing or invalid identity: provide a valid UUID or PURL.")
+            raise ValueError("Missing or invalid identity: provide a valid UUID or PackageURL.")
 
         # Check that only one is provided
         if artifact_identity is not None and artifact_id:
@@ -76,7 +76,7 @@ class StartTestrunRequest(TestrunRequest):
         # Validate artifact_identity format if provided
         if artifact_identity is not None:
             if not isinstance(artifact_identity, str) or not artifact_identity.startswith("pkg:"):
-                raise ValueError("Invalid artifact_identity: must be a valid PURL.")
+                raise ValueError("Invalid artifact_identity: must be a valid PackageURL.")
 
         # Note: artifact_id UUID validation is handled by Pydantic's built-in UUID type validation
 

--- a/python/tests/test_routers.py
+++ b/python/tests/test_routers.py
@@ -262,7 +262,7 @@ class TestRouters(TestCase):
         error_detail = response.json()
         assert "detail" in error_detail
         error_messages = [error["msg"] for error in error_detail["detail"]]
-        expected_message = "Missing or invalid identity: provide a valid UUID"
+        expected_message = "Missing or invalid identity: provide a valid UUID or PackageURL."
         assert any(expected_message in msg for msg in error_messages)
 
     def test_start_etos_empty_artifact_identity_and_none_artifact_id(self):
@@ -295,7 +295,7 @@ class TestRouters(TestCase):
         error_detail = response.json()
         assert "detail" in error_detail
         error_messages = [error["msg"] for error in error_detail["detail"]]
-        expected_message = "Missing or invalid identity: provide a valid UUID"
+        expected_message = "Missing or invalid identity: provide a valid UUID or PackageURL."
         assert any(expected_message in msg for msg in error_messages)
 
     def test_start_etos_both_artifact_identity_and_id_provided(self):

--- a/python/tests/test_routers.py
+++ b/python/tests/test_routers.py
@@ -262,7 +262,7 @@ class TestRouters(TestCase):
         error_detail = response.json()
         assert "detail" in error_detail
         error_messages = [error["msg"] for error in error_detail["detail"]]
-        expected_message = "At least one of 'artifact_identity' or 'artifact_id' is required."
+        expected_message = "Missing or invalid identity: provide a valid UUID"
         assert any(expected_message in msg for msg in error_messages)
 
     def test_start_etos_empty_artifact_identity_and_none_artifact_id(self):
@@ -270,12 +270,12 @@ class TestRouters(TestCase):
 
         Approval criteria:
             - POST requests to ETOS with empty artifact_identity shall return 422.
-            - The error message shall indicate invalid format (empty doesn't start with 'pkg:').
+            - The error message shall indicate that at least one identifier is required.
 
         Test steps::
             1. Send a POST request to etos with empty artifact_identity and None artifact_id.
             2. Verify that the status code is 422.
-            3. Verify that the error message indicates invalid format.
+            3. Verify that the error message indicates at least one is required.
         """
         self.logger.info(
             "STEP: Send a POST request to etos with empty artifact_identity and None artifact_id."
@@ -291,11 +291,11 @@ class TestRouters(TestCase):
         self.logger.info("STEP: Verify that the status code is 422.")
         assert response.status_code == 422
 
-        self.logger.info("STEP: Verify that the error message indicates invalid format.")
+        self.logger.info("STEP: Verify that the error message indicates at least one is required.")
         error_detail = response.json()
         assert "detail" in error_detail
         error_messages = [error["msg"] for error in error_detail["detail"]]
-        expected_message = "artifact_identity must be a string starting with 'pkg:'"
+        expected_message = "Missing or invalid identity: provide a valid UUID"
         assert any(expected_message in msg for msg in error_messages)
 
     def test_start_etos_both_artifact_identity_and_id_provided(self):


### PR DESCRIPTION
### Applicable Issues

Fixes https://github.com/eiffel-community/etos/issues/431

### Description of the Change

Improves validation error messages returned by the ETOS API when identity parameters are missing or invalid. Normalizes empty/whitespace-only artifact_identity to None so the "missing identity" error fires instead of a confusing PURL format error. Updates both v0 and v1alpha schemas.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com