### PR TITLE
Add TTL lease to etcd keys to prevent unbounded growth

### DIFF
--- a/internal/database/etcd/etcd.go
+++ b/internal/database/etcd/etcd.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strconv"
 	"time"
 
 	"github.com/eiffel-community/etos-api/internal/config"
@@ -31,9 +30,9 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
-// defaultTestResultTimeout is the default ETOS test result timeout in seconds,
+// defaultTestResultTimeout is the default ETOS test result timeout,
 // matching the Python default in etos-library (ETOS_DEFAULT_TEST_RESULT_TIMEOUT).
-const defaultTestResultTimeout = 86400
+const defaultTestResultTimeout = 24 * time.Hour
 
 // leaseMargin is extra time added to the test result timeout to form the key TTL,
 // consistent with how etcd_lease_expiration_time is calculated in etos-api.
@@ -41,18 +40,20 @@ const leaseMargin = 10 * time.Minute
 
 // keyTTL returns the time-to-live for keys written to etcd.
 // It reads ETOS_DEFAULT_TEST_RESULT_TIMEOUT from the environment (defaulting to
-// 86400 seconds / 24 hours) and adds a 10-minute margin, matching how the Python
+// 24h) and adds a 10-minute margin, matching how the Python
 // etos-api calculates etcd_lease_expiration_time.
+// The environment variable is parsed with time.ParseDuration and accepts
+// values such as "24h", "48h30m", "86400s", etc.
 // Keys that are not explicitly deleted will expire after this duration,
 // preventing leaked keys from accumulating indefinitely.
 func keyTTL() time.Duration {
 	timeout := defaultTestResultTimeout
 	if val, ok := os.LookupEnv("ETOS_DEFAULT_TEST_RESULT_TIMEOUT"); ok {
-		if parsed, err := strconv.Atoi(val); err == nil && parsed > 0 {
+		if parsed, err := time.ParseDuration(val); err == nil && parsed > 0 {
 			timeout = parsed
 		}
 	}
-	return time.Duration(timeout)*time.Second + leaseMargin
+	return timeout + leaseMargin
 }
 
 // TODO: refactor the client so that it does not store data it fetched.

--- a/internal/database/etcd/etcd.go
+++ b/internal/database/etcd/etcd.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/eiffel-community/etos-api/internal/config"
@@ -29,13 +31,29 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
-// keyTTL is the default time-to-live for keys written to etcd.
+// defaultTestResultTimeout is the default ETOS test result timeout in seconds,
+// matching the Python default in etos-library (ETOS_DEFAULT_TEST_RESULT_TIMEOUT).
+const defaultTestResultTimeout = 86400
+
+// leaseMargin is extra time added to the test result timeout to form the key TTL,
+// consistent with how etcd_lease_expiration_time is calculated in etos-api.
+const leaseMargin = 10 * time.Minute
+
+// keyTTL returns the time-to-live for keys written to etcd.
+// It reads ETOS_DEFAULT_TEST_RESULT_TIMEOUT from the environment (defaulting to
+// 86400 seconds / 24 hours) and adds a 10-minute margin, matching how the Python
+// etos-api calculates etcd_lease_expiration_time.
 // Keys that are not explicitly deleted will expire after this duration,
 // preventing leaked keys from accumulating indefinitely.
-// 24 hours matches the default ETOS test result timeout
-// (ETOS_DEFAULT_TEST_RESULT_TIMEOUT) with a 10-minute margin, consistent
-// with how etcd lease expiration is calculated in etos-api.
-const keyTTL = 24*time.Hour + 10*time.Minute
+func keyTTL() time.Duration {
+	timeout := defaultTestResultTimeout
+	if val, ok := os.LookupEnv("ETOS_DEFAULT_TEST_RESULT_TIMEOUT"); ok {
+		if parsed, err := strconv.Atoi(val); err == nil && parsed > 0 {
+			timeout = parsed
+		}
+	}
+	return time.Duration(timeout)*time.Second + leaseMargin
+}
 
 // TODO: refactor the client so that it does not store data it fetched.
 // However, without it implementing the database.Opener interface would be more complex (methods readByte, read).
@@ -88,7 +106,8 @@ func (etcd Etcd) Write(p []byte) (int, error) {
 	}
 	key := fmt.Sprintf("%s/%s", etcd.treePrefix, etcd.ID.String())
 
-	lease, err := etcd.client.Grant(etcd.ctx, int64(keyTTL.Seconds()))
+	ttl := keyTTL()
+	lease, err := etcd.client.Grant(etcd.ctx, int64(ttl.Seconds()))
 	if err != nil {
 		return 0, fmt.Errorf("failed to create lease for key %s: %w", key, err)
 	}

--- a/internal/database/etcd/etcd.go
+++ b/internal/database/etcd/etcd.go
@@ -29,6 +29,14 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
+// keyTTL is the default time-to-live for keys written to etcd.
+// Keys that are not explicitly deleted will expire after this duration,
+// preventing leaked keys from accumulating indefinitely.
+// 24 hours matches the default ETOS test result timeout
+// (ETOS_DEFAULT_TEST_RESULT_TIMEOUT) with a 10-minute margin, consistent
+// with how etcd lease expiration is calculated in etos-api.
+const keyTTL = 24*time.Hour + 10*time.Minute
+
 // TODO: refactor the client so that it does not store data it fetched.
 // However, without it implementing the database.Opener interface would be more complex (methods readByte, read).
 type Etcd struct {
@@ -62,21 +70,29 @@ func New(cfg config.Config, logger *logrus.Logger, treePrefix string) database.O
 // Open returns a copy of an Etcd client with ID and context added
 func (etcd Etcd) Open(ctx context.Context, id uuid.UUID) io.ReadWriter {
 	return &Etcd{
-		client: etcd.client,
-		cfg:    etcd.cfg,
-		ID:     id,
-		ctx:    ctx,
+		client:     etcd.client,
+		cfg:        etcd.cfg,
+		treePrefix: etcd.treePrefix,
+		ID:         id,
+		ctx:        ctx,
 	}
 }
 
-// Write writes data to etcd
+// Write writes data to etcd with a lease that expires after keyTTL.
+// The lease acts as a safety net: if Delete is never called (e.g. due to a
+// crash or timeout), the key will be automatically removed by etcd after
+// the TTL elapses, preventing unbounded database growth.
 func (etcd Etcd) Write(p []byte) (int, error) {
 	if etcd.ID == uuid.Nil {
 		return 0, errors.New("please create a new etcd client using Open")
 	}
 	key := fmt.Sprintf("%s/%s", etcd.treePrefix, etcd.ID.String())
 
-	_, err := etcd.client.Put(etcd.ctx, key, string(p))
+	lease, err := etcd.client.Grant(etcd.ctx, int64(keyTTL.Seconds()))
+	if err != nil {
+		return 0, fmt.Errorf("failed to create lease for key %s: %w", key, err)
+	}
+	_, err = etcd.client.Put(etcd.ctx, key, string(p), clientv3.WithLease(lease.ID))
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
### Applicable Issues

https://github.com/eiffel-community/etos/issues/639

### Description of the Change

Write() now creates a 24h+10min TTL lease for every key, so leaked keys (from crashes or timeouts) expire automatically instead of persisting forever. The TTL matches `etcd_lease_expiration_time` in etos-api for consistency. Also fixes Open() to propagate treePrefix.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com