### PR TITLE
Improve error when artifact not found in ER

### DIFF
--- a/python/src/etos_api/routers/v0/router.py
+++ b/python/src/etos_api/routers/v0/router.py
@@ -164,7 +164,7 @@ async def _start(etos: StartEtosRequest, span: Span, ctx: otel_context.Context) 
         ) from exception
     if artifact is None:
         if etos.artifact_id is not None:
-            detail = f"Artifact with ID '{etos.artifact_id}' not found" " in the Event Repository."
+            detail = f"Artifact with ID '{etos.artifact_id}' not found in the Event Repository."
         else:
             detail = (
                 f"Artifact with identity '{etos.artifact_identity}' not found"

--- a/python/src/etos_api/routers/v0/router.py
+++ b/python/src/etos_api/routers/v0/router.py
@@ -163,11 +163,14 @@ async def _start(etos: StartEtosRequest, span: Span, ctx: otel_context.Context) 
             status_code=400, detail=f"Could not connect to GraphQL. {exception}"
         ) from exception
     if artifact is None:
-        identity = etos.artifact_identity or str(etos.artifact_id)
-        raise HTTPException(
-            status_code=400,
-            detail=f"Unable to find artifact with identity '{identity}'",
-        )
+        if etos.artifact_id is not None:
+            detail = f"Artifact with ID '{etos.artifact_id}' not found" " in the Event Repository."
+        else:
+            detail = (
+                f"Artifact with identity '{etos.artifact_identity}' not found"
+                " in the Event Repository."
+            )
+        raise HTTPException(status_code=400, detail=detail)
     LOGGER.info("Found artifact created %r", artifact)
     # There are assumptions here. Since "edges" list is already tested
     # and we know that the return from GraphQL must be 'node'.'meta'.'id'

--- a/python/src/etos_api/routers/v1alpha/router.py
+++ b/python/src/etos_api/routers/v1alpha/router.py
@@ -181,7 +181,7 @@ async def _create_testrun(etos: StartTestrunRequest, span: Span, ctx: otel_conte
         ) from exception
     if artifact is None:
         if etos.artifact_id is not None:
-            detail = f"Artifact with ID '{etos.artifact_id}' not found" " in the Event Repository."
+            detail = f"Artifact with ID '{etos.artifact_id}' not found in the Event Repository."
         else:
             detail = (
                 f"Artifact with identity '{etos.artifact_identity}' not found"

--- a/python/src/etos_api/routers/v1alpha/router.py
+++ b/python/src/etos_api/routers/v1alpha/router.py
@@ -180,11 +180,14 @@ async def _create_testrun(etos: StartTestrunRequest, span: Span, ctx: otel_conte
             status_code=400, detail=f"Could not connect to GraphQL. {exception}"
         ) from exception
     if artifact is None:
-        identity = etos.artifact_identity or str(etos.artifact_id)
-        raise HTTPException(
-            status_code=400,
-            detail=f"Unable to find artifact with identity '{identity}'",
-        )
+        if etos.artifact_id is not None:
+            detail = f"Artifact with ID '{etos.artifact_id}' not found" " in the Event Repository."
+        else:
+            detail = (
+                f"Artifact with identity '{etos.artifact_identity}' not found"
+                " in the Event Repository."
+            )
+        raise HTTPException(status_code=400, detail=detail)
     LOGGER.info("Found artifact created %r", artifact)
     # There are assumptions here. Since "edges" list is already tested
     # and we know that the return from GraphQL must be 'node'.'meta'.'id'


### PR DESCRIPTION
### Applicable Issues

Fixes https://github.com/eiffel-community/etos/issues/641

### Description of the Change

Improves the error message returned when an artifact is not found in the Event Repository. The message now clearly states whether the lookup was by artifact ID (UUID) or by identity (PackageURL), making it easier for users to understand what went wrong. Updates both v0 and v1alpha routers.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com