### PR TITLE
Add timeout and deadline parameters to testrun API

### DIFF
--- a/python/src/etos_api/routers/v1alpha/router.py
+++ b/python/src/etos_api/routers/v1alpha/router.py
@@ -250,6 +250,8 @@ async def _create_testrun(etos: StartTestrunRequest, span: Span, ctx: otel_conte
         ),
         spec=TestRunSpec(
             cluster=os.getenv("ETOS_CLUSTER", "Unknown"),
+            timeout=etos.timeout,
+            deadline=etos.deadline,
             id=testrun_id,
             retention=retention,
             suiteRunner=Image(

--- a/python/src/etos_api/routers/v1alpha/schemas.py
+++ b/python/src/etos_api/routers/v1alpha/schemas.py
@@ -20,7 +20,12 @@ from typing import Optional, Union
 from uuid import UUID
 
 # Pylint refrains from linting C extensions due to arbitrary code execution.
-from pydantic import BaseModel, Field, field_validator, model_validator  # pylint:disable=no-name-in-module
+from pydantic import (
+    BaseModel,
+    Field,
+    field_validator,
+    model_validator,
+)  # pylint:disable=no-name-in-module
 
 # pylint: disable=too-few-public-methods
 # pylint: disable=no-self-argument

--- a/python/src/etos_api/routers/v1alpha/schemas.py
+++ b/python/src/etos_api/routers/v1alpha/schemas.py
@@ -46,6 +46,8 @@ class StartTestrunRequest(TestrunRequest):
     )
     iut_provider: Optional[str] = os.getenv("DEFAULT_IUT_PROVIDER", "default")
     log_area_provider: Optional[str] = os.getenv("DEFAULT_LOG_AREA_PROVIDER", "default")
+    timeout: Optional[int] = None
+    deadline: Optional[int] = None
 
     @field_validator("artifact_id")
     def validate_id_or_identity(cls, artifact_id, info):

--- a/python/src/etos_api/routers/v1alpha/schemas.py
+++ b/python/src/etos_api/routers/v1alpha/schemas.py
@@ -20,7 +20,7 @@ from typing import Optional, Union
 from uuid import UUID
 
 # Pylint refrains from linting C extensions due to arbitrary code execution.
-from pydantic import BaseModel, Field, field_validator  # pylint:disable=no-name-in-module
+from pydantic import BaseModel, Field, field_validator, model_validator  # pylint:disable=no-name-in-module
 
 # pylint: disable=too-few-public-methods
 # pylint: disable=no-self-argument
@@ -48,6 +48,20 @@ class StartTestrunRequest(TestrunRequest):
     log_area_provider: Optional[str] = os.getenv("DEFAULT_LOG_AREA_PROVIDER", "default")
     timeout: Optional[int] = None
     deadline: Optional[int] = None
+
+    @model_validator(mode="after")
+    def validate_timeout_or_deadline(self):
+        """Validate that only one of timeout or deadline is set.
+
+        The controller will ignore timeout if deadline is set, so we should
+        prevent users from setting both to avoid confusion.
+
+        :return: The validated model.
+        :rtype: StartTestrunRequest
+        """
+        if self.timeout is not None and self.deadline is not None:
+            raise ValueError("Only one of 'timeout' or 'deadline' can be set, not both.")
+        return self
 
     @field_validator("artifact_id")
     def validate_id_or_identity(cls, artifact_id, info):


### PR DESCRIPTION
### Applicable Issues

Related to https://github.com/eiffel-community/etos/issues/644

### Description of the Change

Accept optional `timeout` (seconds) and `deadline` (unix epoch) parameters in the start testrun request and pass them through to the TestRun CR spec.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com