### PR TITLE
Default provider fields to empty string for webhook resolution

### DIFF
--- a/python/src/etos_api/routers/v1alpha/schemas.py
+++ b/python/src/etos_api/routers/v1alpha/schemas.py
@@ -46,11 +46,9 @@ class StartTestrunRequest(TestrunRequest):
     artifact_id: Optional[UUID] = Field(default=None, validate_default=True)
     test_suite_url: str
     dataset: Union[dict, list[dict]] = {}
-    execution_space_provider: Optional[str] = os.getenv(
-        "DEFAULT_EXECUTION_SPACE_PROVIDER", "default"
-    )
-    iut_provider: Optional[str] = os.getenv("DEFAULT_IUT_PROVIDER", "default")
-    log_area_provider: Optional[str] = os.getenv("DEFAULT_LOG_AREA_PROVIDER", "default")
+    execution_space_provider: Optional[str] = os.getenv("DEFAULT_EXECUTION_SPACE_PROVIDER", "")
+    iut_provider: Optional[str] = os.getenv("DEFAULT_IUT_PROVIDER", "")
+    log_area_provider: Optional[str] = os.getenv("DEFAULT_LOG_AREA_PROVIDER", "")
     timeout: Optional[int] = None
     deadline: Optional[int] = None
 


### PR DESCRIPTION
### Applicable Issues

Related to https://github.com/eiffel-community/etos/issues/669

### Description of the Change

Change v1alpha provider defaults from "default" to empty string so the testrun webhook can resolve default providers from labeled Provider CRDs. This is a companion change to https://github.com/eiffel-community/etos/pull/670.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com