### PR TITLE
Fix validation of digest-pinned test runner images

### DIFF
--- a/python/src/etos_api/library/docker.py
+++ b/python/src/etos_api/library/docker.py
@@ -27,6 +27,7 @@ DEFAULT_TAG = "latest"
 DEFAULT_REGISTRY = "index.docker.io"
 REPO_DELIMITER = "/"
 TAG_DELIMITER = ":"
+DIGEST_DELIMITER = "@"
 
 # Retry configuration for transient connection errors.
 # Uses exponential backoff: delay = BACKOFF_FACTOR * 2^(attempt-1)
@@ -184,6 +185,29 @@ class Docker:
             parameters[key] = value.strip('"')
         return parameters
 
+    def reference(self, name: str) -> tuple[str, str]:
+        """Figure out the manifest reference (tag or digest) from an image name.
+
+        A container image can be referenced by tag (``name:tag``), by content
+        digest (``name@sha256:<hex>``), or by both at once
+        (``name:tag@sha256:<hex>``). When a digest is present it takes
+        precedence over any tag and is returned verbatim so it can be used
+        directly in a manifest URL; the tag, if any, is discarded.
+
+        :param name: Name of image.
+        :return: Base image name without reference and the reference (tag or digest).
+        """
+        # A digest is delimited from the image name by '@' and is used as the
+        # manifest reference verbatim (e.g. 'sha256:<hex>'). If a tag is also
+        # present (name:tag@sha256:<hex>), the tag is discarded in favour of
+        # the digest.
+        if DIGEST_DELIMITER in name:
+            name, digest = name.split(DIGEST_DELIMITER, 1)
+            base, _ = self.tag(name)
+            self.logger.info("Assuming digest reference is %r", digest)
+            return base, digest
+        return self.tag(name)
+
     def tag(self, base: str) -> tuple[str, str]:
         """Figure out tag from a container image name.
 
@@ -239,9 +263,9 @@ class Docker:
         :return: The sha256 digest of the container image.
         """
         self.logger.info("Figure out digest for %r", name)
-        base, tag = self.tag(name)
+        base, reference = self.reference(name)
         registry, repo = self.repository(base)
-        manifest_url = f"https://{registry}/v2/{repo}/manifests/{tag}"
+        manifest_url = f"https://{registry}/v2/{repo}/manifests/{reference}"
         return await self._retry(self._get_digest, name, manifest_url)
 
     async def _retry(

--- a/python/src/etos_api/library/docker.py
+++ b/python/src/etos_api/library/docker.py
@@ -186,7 +186,7 @@ class Docker:
         return parameters
 
     def reference(self, name: str) -> tuple[str, str]:
-        """Figure out the manifest reference (tag or digest) from an image name.
+        """Resolve a manifest tag or digest from an image name.
 
         A container image can be referenced by tag (``name:tag``), by content
         digest (``name@sha256:<hex>``), or by both at once

--- a/python/tests/library/test_docker.py
+++ b/python/tests/library/test_docker.py
@@ -201,6 +201,8 @@ class TestDockerDigestRetry:
 class TestDockerReferenceParsing:
     """Test parsing of image references (tag and digest) by Docker."""
 
+    logger = logging.getLogger(__name__)
+
     @pytest.mark.parametrize(
         "name, expected_base, expected_reference",
         [
@@ -264,13 +266,7 @@ class TestDockerReferenceParsing:
         assert base == expected_base
         assert reference == expected_reference
 
-
-class TestDockerManifestUrl:
-    """Test the manifest URL built by Docker.digest."""
-
-    logger = logging.getLogger(__name__)
-    pytestmark = pytest.mark.asyncio
-
+    @pytest.mark.asyncio
     @patch.object(Docker, "_get_digest", new_callable=AsyncMock)
     async def test_digest_pinned_image_builds_correct_manifest_url(self, mock_get_digest):
         """Test that a digest-pinned image produces a digest-based manifest URL.
@@ -291,6 +287,7 @@ class TestDockerManifestUrl:
             f"https://ghcr.io/v2/eiffel-community/etos-test-runner/manifests/{digest}"
         )
 
+    @pytest.mark.asyncio
     @patch.object(Docker, "_get_digest", new_callable=AsyncMock)
     async def test_tag_based_image_builds_correct_manifest_url(self, mock_get_digest):
         """Test that a tag-based image produces a tag-based manifest URL.

--- a/python/tests/library/test_docker.py
+++ b/python/tests/library/test_docker.py
@@ -196,3 +196,115 @@ class TestDockerDigestRetry:
         # Delays: BACKOFF_FACTOR * 2^0, BACKOFF_FACTOR * 2^1, BACKOFF_FACTOR * 2^2
         # No sleep after the last attempt.
         assert recorded_delays == [1, 2, 4]
+
+
+class TestDockerReferenceParsing:
+    """Test parsing of image references (tag and digest) by Docker."""
+
+    @pytest.mark.parametrize(
+        "name, expected_base, expected_reference",
+        [
+            # Tag-based references.
+            ("etos-test-runner", "etos-test-runner", "latest"),
+            ("etos-test-runner:1.2.3", "etos-test-runner", "1.2.3"),
+            (
+                "ghcr.io/eiffel-community/etos-test-runner:latest",
+                "ghcr.io/eiffel-community/etos-test-runner",
+                "latest",
+            ),
+            # Registry with port and no tag must not confuse the port for a tag.
+            (
+                "registry.example.com:5000/etos-test-runner",
+                "registry.example.com:5000/etos-test-runner",
+                "latest",
+            ),
+            (
+                "registry.example.com:5000/etos-test-runner:1.2.3",
+                "registry.example.com:5000/etos-test-runner",
+                "1.2.3",
+            ),
+            # Digest-pinned references must use the digest verbatim.
+            (
+                "ghcr.io/eiffel-community/etos-test-runner@sha256:" + "a" * 64,
+                "ghcr.io/eiffel-community/etos-test-runner",
+                "sha256:" + "a" * 64,
+            ),
+            (
+                "etos-test-runner@sha256:" + "b" * 64,
+                "etos-test-runner",
+                "sha256:" + "b" * 64,
+            ),
+            # Registry with port and digest.
+            (
+                "registry.example.com:5000/etos-test-runner@sha256:" + "c" * 64,
+                "registry.example.com:5000/etos-test-runner",
+                "sha256:" + "c" * 64,
+            ),
+            # Both tag and digest present: the digest wins and the tag is dropped.
+            (
+                "ghcr.io/eiffel-community/etos-test-runner:1.2.3@sha256:" + "d" * 64,
+                "ghcr.io/eiffel-community/etos-test-runner",
+                "sha256:" + "d" * 64,
+            ),
+        ],
+    )
+    def test_reference(self, name, expected_base, expected_reference):
+        """Test that reference returns the correct base image and reference.
+
+        Approval criteria:
+            - Tag-based references shall be parsed into base image and tag.
+            - Digest-pinned references shall be parsed into base image and digest.
+
+        Test steps::
+            1. Call reference with an image name.
+            2. Verify the returned base image and reference are correct.
+        """
+        docker = Docker()
+        base, reference = docker.reference(name)
+        assert base == expected_base
+        assert reference == expected_reference
+
+
+class TestDockerManifestUrl:
+    """Test the manifest URL built by Docker.digest."""
+
+    logger = logging.getLogger(__name__)
+    pytestmark = pytest.mark.asyncio
+
+    @patch.object(Docker, "_get_digest", new_callable=AsyncMock)
+    async def test_digest_pinned_image_builds_correct_manifest_url(self, mock_get_digest):
+        """Test that a digest-pinned image produces a digest-based manifest URL.
+
+        Approval criteria:
+            - The manifest URL for a digest-pinned image shall reference the digest
+              verbatim, not parse it as a tag.
+
+        Test steps::
+            1. Call digest with a digest-pinned image name.
+            2. Verify the manifest URL passed to _get_digest uses the digest.
+        """
+        mock_get_digest.return_value = "sha256:" + "a" * 64
+        docker = Docker()
+        digest = "sha256:" + "a" * 64
+        await docker.digest(f"ghcr.io/eiffel-community/etos-test-runner@{digest}")
+        mock_get_digest.assert_awaited_once_with(
+            f"https://ghcr.io/v2/eiffel-community/etos-test-runner/manifests/{digest}"
+        )
+
+    @patch.object(Docker, "_get_digest", new_callable=AsyncMock)
+    async def test_tag_based_image_builds_correct_manifest_url(self, mock_get_digest):
+        """Test that a tag-based image produces a tag-based manifest URL.
+
+        Approval criteria:
+            - The manifest URL for a tag-based image shall reference the tag.
+
+        Test steps::
+            1. Call digest with a tag-based image name.
+            2. Verify the manifest URL passed to _get_digest uses the tag.
+        """
+        mock_get_digest.return_value = "sha256:abc123"
+        docker = Docker()
+        await docker.digest("ghcr.io/eiffel-community/etos-test-runner:1.2.3")
+        mock_get_digest.assert_awaited_once_with(
+            "https://ghcr.io/v2/eiffel-community/etos-test-runner/manifests/1.2.3"
+        )


### PR DESCRIPTION
### Applicable Issues

Fixes https://github.com/eiffel-community/etos/issues/710

### Description of the Change

Add a `reference()` helper that resolves the manifest reference from an image name, using a digest (`name@sha256:<hex>`) verbatim when present and falling back to tag parsing otherwise, so digest-pinned test runner images validate against the registry instead of failing with a 404. Add tests covering tag-only, digest-only, registry-with-port, and combined tag+digest references.

### Alternate Designs

None.

### Possible Drawbacks

None identified; tag-based references continue to behave exactly as before.

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com