### PR TITLE
Update pinned Alpine package versions in Dockerfiles

### DIFF
--- a/deploy/etos-executionspace/Dockerfile
+++ b/deploy/etos-executionspace/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.26-alpine AS build
 WORKDIR /tmp/executionspace
 
 # Cache dependencies early
-RUN apk add --no-cache make=4.4.1-r3 git=2.52.0-r0
+RUN apk add --no-cache make=4.4.1-r4 git=2.54.0-r0
 COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download

--- a/deploy/etos-iut/Dockerfile
+++ b/deploy/etos-iut/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.26-alpine AS build
 WORKDIR /tmp/iut
 
 # Cache dependencies early
-RUN apk add --no-cache make=4.4.1-r3 git=2.52.0-r0
+RUN apk add --no-cache make=4.4.1-r4 git=2.54.0-r0
 COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download

--- a/deploy/etos-keys/Dockerfile
+++ b/deploy/etos-keys/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.26-alpine AS build
 WORKDIR /tmp/keys
 
 # Cache dependencies early
-RUN apk add --no-cache make=4.4.1-r3 git=2.52.0-r0
+RUN apk add --no-cache make=4.4.1-r4 git=2.54.0-r0
 COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download

--- a/deploy/etos-logarea/Dockerfile
+++ b/deploy/etos-logarea/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.26-alpine AS build
 WORKDIR /tmp/logarea
 
 # Cache dependencies early
-RUN apk add --no-cache make=4.4.1-r3 git=2.52.0-r0
+RUN apk add --no-cache make=4.4.1-r4 git=2.54.0-r0
 COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download

--- a/deploy/etos-sse/Dockerfile
+++ b/deploy/etos-sse/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.26-alpine AS build
 WORKDIR /tmp/sse
 
 # Cache dependencies early
-RUN apk add --no-cache make=4.4.1-r3 git=2.52.0-r0
+RUN apk add --no-cache make=4.4.1-r4 git=2.54.0-r0
 COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download


### PR DESCRIPTION
### Applicable Issues

### Description of the Change

Update pinned make and git versions in all Go service Dockerfiles to match the versions currently available in the golang:1.26-alpine base image, fixing CI build failures.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: , 