### PR TITLE
Add a v1beta1 router for creating testruns

### DIFF
--- a/python/src/etos_api/routers/v0/router.py
+++ b/python/src/etos_api/routers/v0/router.py
@@ -130,6 +130,7 @@ async def _start(etos: StartEtosRequest, span: Span, ctx: otel_context.Context) 
     tercc = EiffelTestExecutionRecipeCollectionCreatedEvent()
     LOGGER.identifier.set(tercc.meta.event_id)
     span.set_attribute("etos.id", tercc.meta.event_id)
+    span.set_attribute("etos.version", ETOSV0.version)
     span.set_attribute(
         "parent_activity", str(etos.parent_activity) if etos.parent_activity else "None"
     )

--- a/python/src/etos_api/routers/v1alpha/router.py
+++ b/python/src/etos_api/routers/v1alpha/router.py
@@ -22,9 +22,9 @@ from uuid import uuid4
 
 from etos_lib import ETOS
 from etos_lib.kubernetes import Environment, Kubernetes, TestRun
-from etos_lib.kubernetes.schemas.testrun import Image, Metadata, Providers, Retention
-from etos_lib.kubernetes.schemas.testrun import TestRun as TestRunSchema
-from etos_lib.kubernetes.schemas.testrun import TestRunner, TestRunSpec
+from etos_lib.kubernetes.schemas.v1alpha1.testrun import Image, Metadata, Providers, Retention
+from etos_lib.kubernetes.schemas.v1alpha1.testrun import TestRun as TestRunSchema
+from etos_lib.kubernetes.schemas.v1alpha1.testrun import TestRunner, TestRunSpec
 from fastapi import Depends, FastAPI, HTTPException
 from opentelemetry import baggage as otel_baggage
 from opentelemetry import context as otel_context

--- a/python/src/etos_api/routers/v1alpha/router.py
+++ b/python/src/etos_api/routers/v1alpha/router.py
@@ -147,6 +147,7 @@ async def _create_testrun(etos: StartTestrunRequest, span: Span, ctx: otel_conte
     testrun_id = str(uuid4())
     LOGGER.identifier.set(testrun_id)
     span.set_attribute("etos.id", testrun_id)
+    span.set_attribute("etos.version", ETOSV1ALPHA.version)
 
     LOGGER.info("Download test suite.")
     span.set_attribute("etos.test_suite.uri", etos.test_suite_url)

--- a/python/src/etos_api/routers/v1beta1/__init__.py
+++ b/python/src/etos_api/routers/v1beta1/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Axis Communications AB.
+# Copyright Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -13,20 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""ETOS API."""
+"""ETOS API testrun module."""
 
-from fastapi import FastAPI
-from prometheus_client import make_asgi_app
-
-from etos_api.routers.v0 import ETOSV0
-from etos_api.routers.v1alpha import ETOSV1ALPHA
-from etos_api.routers.v1beta1 import ETOSV1BETA1
-
-DEFAULT_VERSION = ETOSV0
-
-APP = FastAPI()
-APP.mount("/api/v1alpha", ETOSV1ALPHA, "ETOS V1 Alpha")
-APP.mount("/api/v1beta1", ETOSV1BETA1, "ETOS V1 Beta")
-APP.mount("/api/v0", ETOSV0, "ETOS V0")
-APP.mount("/api", DEFAULT_VERSION, "ETOS V0")
-APP.mount("/metrics", make_asgi_app(), "Metrics")
+from . import schemas
+from .router import ETOSV1BETA1

--- a/python/src/etos_api/routers/v1beta1/router.py
+++ b/python/src/etos_api/routers/v1beta1/router.py
@@ -139,6 +139,20 @@ async def _create_testrun(etos: StartTestrunRequest, span: Span, ctx: otel_conte
     test_suite = await testrun.download_suite(etos.test_suite_url)
     testrun_spec = await testrun.validate_suite(test_suite)
 
+    datasets = etos.dataset
+    if isinstance(datasets, list):
+        if len(datasets) != len(testrun_spec.suites):
+            raise HTTPException(
+                status_code=400,
+                detail="If multiple datasets are provided, the number of datasets must correspond"
+                " with number of test suites",
+            )
+    else:
+        datasets = [datasets] * len(testrun_spec.suites)
+
+    for suite in testrun_spec.suites:
+        suite.dataset.update(datasets.pop(0))
+
     artifact = await testrun.wait_for_artifact(str(etos.artifact_id), etos.artifact_identity)
     testrun_name = await testrun.generate_name(testrun_spec.name)
     await testrun.create(ctx, etos, testrun_name, artifact, testrun_spec)

--- a/python/src/etos_api/routers/v1beta1/router.py
+++ b/python/src/etos_api/routers/v1beta1/router.py
@@ -1,0 +1,160 @@
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ETOS testrun router."""
+
+import logging
+from typing import Annotated
+
+from etos_lib.kubernetes import Environment, Kubernetes
+from fastapi import Depends, FastAPI, HTTPException
+from kubernetes.dynamic.exceptions import NotFoundError
+from opentelemetry import context as otel_context
+from opentelemetry import trace
+from opentelemetry.trace import Span
+from starlette.responses import Response
+
+from etos_api.library.metrics import COUNT_REQUESTS, OPERATIONS, REQUEST_TIME
+from etos_api.library.opentelemetry import context
+
+from .schemas import (AbortTestrunResponse, StartTestrunRequest,
+                      StartTestrunResponse)
+from .testrun import TestRun
+
+ETOSV1BETA1 = FastAPI(
+    title="ETOS",
+    version="v1beta1",
+    summary="API endpoints for ETOS v1 Alpha",
+    root_path_in_servers=False,
+    dependencies=[Depends(context)],
+)
+
+API = f"/api/{ETOSV1BETA1.version}/testrun"
+START_LABELS = {"endpoint": API, "operation": OPERATIONS.start_testrun.name}
+# The key {suite_id} is supposed to indicate that this is a path parameter, but
+# we don't want to set the actual value in the metrics label since that would create
+# a high cardinality metric. Therefore we use the literal string "{suite_id}".
+STOP_LABELS = {"endpoint": f"{API}/{{suite_id}}", "operation": OPERATIONS.stop_testrun.name}
+SUBSUITE_LABELS = {
+    "endpoint": f"{API}/{{suite_id}}",
+    "operation": OPERATIONS.get_subsuite.name,
+}
+
+TRACER = trace.get_tracer("etos_api.routers.testrun.router")
+LOGGER = logging.getLogger(__name__)
+logging.getLogger("pika").setLevel(logging.WARNING)
+# pylint:disable=too-many-locals,too-many-statements
+
+
+@REQUEST_TIME.labels(**START_LABELS).time()
+@COUNT_REQUESTS(START_LABELS, LOGGER)
+@ETOSV1BETA1.post("/testrun", tags=["etos"], response_model=StartTestrunResponse)
+async def start_testrun(
+    etos: StartTestrunRequest, ctx: Annotated[otel_context.Context, Depends(context)]
+) -> dict:
+    """Start ETOS testrun on post.
+
+    :param etos: ETOS pydantic model.
+    :type etos: :obj:`etos_api.routers.etos.schemas.StartTestrunRequest`
+    :param ctx: OpenTelemetry context with extracted headers.
+    :type ctx: :obj:`opentelemetry.context.Context`
+    :return: JSON dictionary with response.
+    :rtype: dict
+    """
+    with TRACER.start_as_current_span("start-etos", context=ctx) as span:
+        return await _create_testrun(etos, span, otel_context.get_current())
+
+
+@REQUEST_TIME.labels(**STOP_LABELS).time()
+@COUNT_REQUESTS(STOP_LABELS, LOGGER)
+@ETOSV1BETA1.delete("/testrun/{suite_id}", tags=["etos"], response_model=AbortTestrunResponse)
+async def abort_testrun(
+    suite_id: str, ctx: Annotated[otel_context.Context, Depends(context)]
+) -> dict:
+    """Abort ETOS testrun on delete.
+
+    :param suite_id: ETOS suite id
+    :type suite_id: str
+    :param ctx: OpenTelemetry context with extracted headers.
+    :type ctx: :obj:`opentelemetry.context.Context`
+    :return: JSON dictionary with response.
+    :rtype: dict
+    """
+    with TRACER.start_as_current_span("abort-etos", context=ctx) as span:
+        return await _abort(suite_id, span)
+
+
+# The key {suite_id} is supposed to indicate that this is a path parameter, but
+# we don't want to set the actual value in the metrics label since that would create
+# a high cardinality metric. Therefore we use the literal string "{sub_suite_id}".
+@REQUEST_TIME.labels(**SUBSUITE_LABELS).time()
+@COUNT_REQUESTS(SUBSUITE_LABELS, LOGGER)
+@ETOSV1BETA1.get("/testrun/{sub_suite_id}", tags=["etos"])
+async def get_subsuite(sub_suite_id: str) -> dict:
+    """Get sub suite returns the sub suite definition for the ETOS test runner.
+
+    Still uses v1alpha of Environment since it does not yet have a v1beta1 version.
+
+    :param sub_suite_id: The name of the Environment kubernetes resource.
+    :return: JSON dictionary with the Environment spec. Formatted to TERCC format.
+    """
+    environment_client = Environment(Kubernetes(version="v1beta1"))
+    try:
+        environment_resource = environment_client.get(sub_suite_id)
+        if not environment_resource:
+            raise HTTPException(404, "Environment not found")
+    except NotFoundError:
+        raise HTTPException(404, "Environment not found")
+    environment_spec = environment_resource.to_dict().get("spec", {})
+    return environment_spec
+
+
+@ETOSV1BETA1.get("/ping", tags=["etos"], status_code=204)
+async def health_check():
+    """Check the status of the API and verify the client version."""
+    return Response(status_code=204)
+
+
+async def _create_testrun(etos: StartTestrunRequest, span: Span, ctx: otel_context.Context) -> dict:
+    """Create a testrun for ETOS to execute.
+
+    :param etos: Testrun pydantic model.
+    :param span: An opentelemetry span for tracing.
+    :param ctx: OpenTelemetry context with extracted headers.
+    :return: JSON dictionary with response.
+    """
+    testrun = TestRun(span)
+
+    test_suite = await testrun.download_suite(etos.test_suite_url)
+    testrun_spec = await testrun.validate_suite(test_suite)
+
+    artifact = await testrun.wait_for_artifact(str(etos.artifact_id), etos.artifact_identity)
+    testrun_name = await testrun.generate_name(testrun_spec.name)
+    await testrun.create(ctx, etos, testrun_name, artifact, testrun_spec)
+
+    return {
+        "tercc": testrun.testrun_id,
+        "artifact_id": artifact.artifact_id,
+        "artifact_identity": artifact.identity,
+        "event_repository": testrun.etos_library.debug.graphql_server,
+    }
+
+
+async def _abort(suite_id: str, span: Span) -> dict:
+    """Abort a testrun by deleting the testrun resource."""
+    testrun = TestRun(span)
+    if not await testrun.delete(suite_id):
+        raise HTTPException(status_code=404, detail="Suite ID not found.")
+    return {"message": f"Abort triggered for suite id: {suite_id}."}

--- a/python/src/etos_api/routers/v1beta1/router.py
+++ b/python/src/etos_api/routers/v1beta1/router.py
@@ -29,8 +29,7 @@ from starlette.responses import Response
 from etos_api.library.metrics import COUNT_REQUESTS, OPERATIONS, REQUEST_TIME
 from etos_api.library.opentelemetry import context
 
-from .schemas import (AbortTestrunResponse, StartTestrunRequest,
-                      StartTestrunResponse)
+from .schemas import AbortTestrunResponse, StartTestrunRequest, StartTestrunResponse
 from .testrun import TestRun
 
 ETOSV1BETA1 = FastAPI(
@@ -115,8 +114,8 @@ async def get_subsuite(sub_suite_id: str) -> dict:
         environment_resource = environment_client.get(sub_suite_id)
         if not environment_resource:
             raise HTTPException(404, "Environment not found")
-    except NotFoundError:
-        raise HTTPException(404, "Environment not found")
+    except NotFoundError as error:
+        raise HTTPException(404, "Environment not found") from error
     environment_spec = environment_resource.to_dict().get("spec", {})
     return environment_spec
 

--- a/python/src/etos_api/routers/v1beta1/schemas.py
+++ b/python/src/etos_api/routers/v1beta1/schemas.py
@@ -1,0 +1,117 @@
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Schemas for the testrun endpoint."""
+
+import os
+from typing import Optional, Union
+from uuid import UUID
+
+# Pylint refrains from linting C extensions due to arbitrary code execution.
+from pydantic import (
+    BaseModel,
+    Field,
+    field_validator,
+    model_validator,
+)  # pylint:disable=no-name-in-module
+
+# pylint: disable=too-few-public-methods
+# pylint: disable=no-self-argument
+
+
+class TestrunRequest(BaseModel):
+    """Base class for testrun request models."""
+
+
+class TestrunResponse(BaseModel):
+    """Base class for testrun response models."""
+
+
+class StartTestrunRequest(TestrunRequest):
+    """Request model for the start endpoint of the ETOS testrun API."""
+
+    artifact_identity: Optional[str]
+    artifact_id: Optional[UUID] = Field(default=None, validate_default=True)
+    test_suite_url: str
+    dataset: Union[dict, list[dict]] = {}
+    execution_space_provider: Optional[str] = os.getenv("DEFAULT_EXECUTION_SPACE_PROVIDER", "")
+    iut_provider: Optional[str] = os.getenv("DEFAULT_IUT_PROVIDER", "")
+    log_area_provider: Optional[str] = os.getenv("DEFAULT_LOG_AREA_PROVIDER", "")
+    timeout: Optional[int] = None
+    deadline: Optional[int] = None
+
+    @model_validator(mode="after")
+    def validate_timeout_or_deadline(self):
+        """Validate that only one of timeout or deadline is set.
+
+        The controller will ignore timeout if deadline is set, so we should
+        prevent users from setting both to avoid confusion.
+
+        :return: The validated model.
+        :rtype: StartTestrunRequest
+        """
+        if self.timeout is not None and self.deadline is not None:
+            raise ValueError("Only one of 'timeout' or 'deadline' can be set, not both.")
+        return self
+
+    @field_validator("artifact_id")
+    def validate_id_or_identity(cls, artifact_id, info):
+        """Validate that id/identity is set correctly.
+
+        :param artifact_id: The value of 'artifact_id' to validate.
+        :value artifact_id: str or None
+        :param info: The information about the model.
+        :type info: FieldValidationInfo
+        :return: The value of artifact_id.
+        :rtype: str or None
+        """
+        values = info.data
+        artifact_identity = values.get("artifact_identity")
+
+        # Treat empty/whitespace-only identity as not provided
+        if isinstance(artifact_identity, str) and not artifact_identity.strip():
+            artifact_identity = None
+
+        # Check that at least one is provided
+        if artifact_identity is None and not artifact_id:
+            raise ValueError("Missing or invalid identity: provide a valid UUID or PackageURL.")
+
+        # Check that only one is provided
+        if artifact_identity is not None and artifact_id:
+            raise ValueError("Only one of 'artifact_identity' or 'artifact_id' is required.")
+
+        # Validate artifact_identity format if provided
+        if artifact_identity is not None:
+            if not isinstance(artifact_identity, str) or not artifact_identity.startswith("pkg:"):
+                raise ValueError("Invalid artifact_identity: must be a valid PackageURL.")
+
+        # Note: artifact_id UUID validation is handled by Pydantic's built-in UUID type validation
+
+        return artifact_id
+
+
+class StartTestrunResponse(TestrunResponse):
+    """Response model for the start endpoint of the ETOS testrun API."""
+
+    event_repository: str
+    tercc: UUID
+    artifact_id: UUID
+    artifact_identity: str
+
+
+class AbortTestrunResponse(TestrunResponse):
+    """Response model for the abort endpoint of the ETOS testrun API."""
+
+    message: str

--- a/python/src/etos_api/routers/v1beta1/testrun.py
+++ b/python/src/etos_api/routers/v1beta1/testrun.py
@@ -111,9 +111,9 @@ class TestRun:
                 test_runner = execution.environment.testRunner
                 if test_runner in checked:
                     continue
-                assert await docker.digest(test_runner) is not None, (
-                    f"Test runner {test_runner} not found"
-                )
+                assert (
+                    await docker.digest(test_runner) is not None
+                ), f"Test runner {test_runner} not found"
                 checked.add(test_runner)
         return testrun
 

--- a/python/src/etos_api/routers/v1beta1/testrun.py
+++ b/python/src/etos_api/routers/v1beta1/testrun.py
@@ -24,10 +24,8 @@ import requests
 from etos_lib import ETOS
 from etos_lib.kubernetes import Kubernetes
 from etos_lib.kubernetes import TestRun as TestRunClient
-from etos_lib.kubernetes.schemas.v1beta1_testrun import (Metadata, Providers,
-                                                         Retention, Suite)
-from etos_lib.kubernetes.schemas.v1beta1_testrun import \
-    TestRun as TestRunSchema
+from etos_lib.kubernetes.schemas.v1beta1_testrun import Metadata, Providers, Retention, Suite
+from etos_lib.kubernetes.schemas.v1beta1_testrun import TestRun as TestRunSchema
 from etos_lib.kubernetes.schemas.v1beta1_testrun import TestRunSpec
 from fastapi import HTTPException
 from opentelemetry import baggage as otel_baggage

--- a/python/src/etos_api/routers/v1beta1/testrun.py
+++ b/python/src/etos_api/routers/v1beta1/testrun.py
@@ -1,0 +1,255 @@
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ETOS testrun."""
+
+import logging
+import os
+from typing import Optional
+from uuid import uuid4
+
+import requests
+from etos_lib import ETOS
+from etos_lib.kubernetes import Kubernetes
+from etos_lib.kubernetes import TestRun as TestRunClient
+from etos_lib.kubernetes.schemas.v1beta1_testrun import (Metadata, Providers,
+                                                         Retention, Suite)
+from etos_lib.kubernetes.schemas.v1beta1_testrun import \
+    TestRun as TestRunSchema
+from etos_lib.kubernetes.schemas.v1beta1_testrun import TestRunSpec
+from fastapi import HTTPException
+from opentelemetry import baggage as otel_baggage
+from opentelemetry import context as otel_context
+from opentelemetry.propagate import inject
+from opentelemetry.trace import Span
+from pydantic import BaseModel
+from yaml import safe_load
+
+from etos_api.library.docker import Docker
+
+from .schemas import StartTestrunRequest
+from .utilities import convert_to_rfc1123, wait_for_artifact_created
+
+
+class MinimalSpec(BaseModel):
+    """Minimal schema for validating the test suite.
+
+    This is a subset of the TestRunSpec schema used for creating the testrun resource in Kubernetes.
+    It is used to validate the test suite before creating the testrun resource, to ensure that all
+    required fields are present and valid before proceeding with the testrun creation process.
+    """
+
+    name: str
+    schemaVersion: str
+    suites: list[Suite]
+
+
+class Artifact(BaseModel):
+    """Class representing an artifact in the Event Repository."""
+
+    artifact_id: str
+    identity: str
+
+
+class TestRun:
+    """Class representing a testrun in ETOS.
+
+    Responsible for downloading and validating the test suite,
+    waiting for the artifact to be created in the Event Repository, and
+    creating the testrun resource in Kubernetes for ETOS to execute.
+    """
+
+    logger = logging.getLogger(__name__)
+
+    def __init__(self, span: Span):
+        """Initialize the TestRun class."""
+        self.testrun_id = str(uuid4())
+        self.span = span
+        self.logger.identifier.set(self.testrun_id)
+        self.etos_library = ETOS("ETOS API", os.getenv("HOSTNAME", "localhost"), "ETOS API")
+        span.set_attribute("etos.id", self.testrun_id)
+        span.set_attribute("etos.version", "v1beta1")
+
+    async def download_suite(self, url: str) -> dict:
+        """Download the test suite from the provided URL."""
+        self.logger.info("Downloading test suite %r", url)
+        self.span.set_attribute("etos.test_suite.uri", url)
+        try:
+            response = requests.get(url, timeout=60)
+            response.raise_for_status()
+        except Exception as exception:  # pylint:disable=broad-except
+            raise AssertionError(f"Unable to download suite from {url}") from exception
+        self.logger.info("Test suite downloaded")
+        return safe_load(response.content)
+
+    async def validate_suite(self, test_suite: dict) -> MinimalSpec:
+        """Validate the test suite against the MinimalSpec schema."""
+        self.logger.info("Validating test suite")
+        self.logger.debug(test_suite)
+        testrun = MinimalSpec.model_validate(test_suite)
+        await self.validate_test_runners(testrun)
+        self.logger.info("Test suite validated")
+        return testrun
+
+    async def validate_test_runners(self, testrun: MinimalSpec):
+        """Validate that all test runners in the test suite are available in the Docker registry."""
+        docker = Docker()
+        checked = set()
+        for suite in testrun.suites:
+            for execution in suite.testExecutions:
+                test_runner = execution.environment.testRunner
+                if test_runner in checked:
+                    continue
+                assert (
+                    await docker.digest(test_runner) is not None
+                ), f"Test runner {test_runner} not found"
+                checked.add(test_runner)
+        return testrun
+
+    async def wait_for_artifact(
+        self, artifact_id: Optional[str], identity: Optional[str]
+    ) -> Artifact:
+        """Wait for an artifact to be created in the Event Repository.
+
+        The artifact can be identified by either its ID or its identity.
+        """
+        self.logger.info("Get artifact created %r", (identity or artifact_id))
+        try:
+            artifact = await wait_for_artifact_created(self.etos_library, identity, artifact_id)
+        except TimeoutError as error:
+            self.logger.warning("Timeout error while waiting for artifact.")
+            raise HTTPException(
+                status_code=504,
+                detail=(f"Timeout waiting for artifact {identity or artifact_id}, retry in 30s"),
+                headers={"Retry-After": "30"},
+            ) from error
+        except Exception as exception:  # pylint:disable=broad-except
+            self.logger.critical(exception)
+            raise HTTPException(
+                status_code=400, detail=f"Could not connect to GraphQL. {exception}"
+            ) from exception
+        if artifact is None:
+            if artifact_id is not None:
+                detail = f"Artifact with ID '{artifact_id}' not found in the Event Repository."
+            else:
+                detail = f"Artifact with identity '{identity}' not found in the Event Repository."
+            raise HTTPException(status_code=400, detail=detail)
+        # There are assumptions here. Since "edges" list is already tested
+        # and we know that the return from GraphQL must be 'node'.'meta'.'id'
+        # if there are "edges", this is fine.
+        # Same goes for 'data'.'identity'.
+        artifact_id = artifact[0]["node"]["meta"]["id"]
+        identity = artifact[0]["node"]["data"]["identity"]
+        assert artifact_id is not None, "Artifact ID not found in GraphQL response"
+        assert identity is not None, "Artifact identity not found in GraphQL response"
+        self.span.set_attribute("etos.artifact.id", artifact_id)
+        self.span.set_attribute("etos.artifact.identity", identity)
+
+        self.logger.info("Found artifact created %r", artifact)
+        return Artifact(artifact_id=artifact_id, identity=identity)
+
+    async def generate_name(self, testrun_name: str) -> str:
+        """Generate a name for the testrun resource in Kubernetes.
+
+        The name is generated from the testrun name provided in the test suite.
+        """
+        # Convert to kubernetes accepted name
+        name = convert_to_rfc1123(testrun_name)
+        # Truncate and Add a hyphen at the end, if possible since it makes the generated name
+        # easier to read. This truncation does not need to be validated since the generateName we
+        # use when creating a TestRun will truncate the string if necessary.
+        if not name.endswith("-"):
+            # 63 is the max length, 5 is the random characters added by generateName and
+            # 1 is to be able to fit a hyphen at the end so we truncate to 57 to fit everything.
+            name = f"{name[:57]}-"
+        return name
+
+    async def create(
+        self,
+        ctx: otel_context.Context,
+        etos: StartTestrunRequest,
+        name: str,
+        artifact: Artifact,
+        minimal_spec: MinimalSpec,
+    ):
+        """Create a testrun resource in Kubernetes for ETOS to execute."""
+        self.logger.info("Creating testrun with name: %r", name)
+        self.logger.debug(artifact)
+        self.logger.debug(minimal_spec)
+
+        ctx = otel_baggage.set_baggage("testrun_id", self.testrun_id, context=ctx)
+        ctx = otel_baggage.set_baggage("artifact_id", artifact.artifact_id, context=ctx)
+        ctx = otel_baggage.set_baggage(
+            "etos_cluster", os.getenv("ETOS_CLUSTER", "Unknown"), context=ctx
+        )
+        carrier: dict = {}
+        # inject() creates a dict with context reference,
+        # e. g. {'traceparent': '00-0be6c260d9cbe9772298eaf19cb90a5b-371353ee8fbd3ced-01'}
+        inject(carrier, context=ctx)
+
+        annotations = {}
+        if carrier.get("traceparent"):
+            annotations["etos.eiffel-community.github.io/traceparent"] = carrier["traceparent"]
+        if carrier.get("baggage"):
+            annotations["etos.eiffel-community.github.io/baggage"] = carrier["baggage"]
+
+        kubernetes = Kubernetes(version="v1beta1")
+        testrun = TestRunSchema(
+            metadata=Metadata(
+                generateName=name,
+                namespace=kubernetes.namespace,
+                labels={
+                    "etos.eiffel-community.github.io/id": self.testrun_id,
+                    "etos.eiffel-community.github.io/cluster": os.getenv("ETOS_CLUSTER", "Unknown"),
+                },
+                annotations=annotations,
+            ),
+            spec=TestRunSpec(
+                schemaVersion=minimal_spec.schemaVersion,
+                name=minimal_spec.name,
+                suites=minimal_spec.suites,
+                id=self.testrun_id,
+                artifact=artifact.artifact_id,
+                identity=artifact.identity,
+                cluster=os.getenv("ETOS_CLUSTER"),
+                providers=Providers(
+                    iut=etos.iut_provider,
+                    executionSpace=etos.execution_space_provider,
+                    logArea=etos.log_area_provider,
+                ),
+                suiteSource=etos.test_suite_url,
+                timeout=etos.timeout,
+                deadline=etos.deadline,
+                retention=Retention(
+                    failure=os.getenv("TESTRUN_FAILURE_RETENTION"),
+                    success=os.getenv("TESTRUN_SUCCESS_RETENTION"),
+                ),
+            ),
+        )
+        testrun_client = TestRunClient(kubernetes)
+        if not testrun_client.create(testrun):
+            raise HTTPException(status_code=500, detail="Failed to create testrun")
+        self.logger.info("ETOS triggered successfully")
+
+    async def delete(self, suite_id: str) -> bool:
+        """Delete a testrun by suite_id. Returns True if a testrun was deleted, False otherwise."""
+        kubernetes = Kubernetes(version="v1beta1")
+        testrun_client = TestRunClient(kubernetes)
+        response = testrun_client.client.delete(
+            type="TestRun",
+            namespace=testrun_client.namespace,
+            field_selector=f"spec.id={suite_id}",
+        )  # type: ignore
+        return response and response.items and len(response.items) > 0

--- a/python/src/etos_api/routers/v1beta1/testrun.py
+++ b/python/src/etos_api/routers/v1beta1/testrun.py
@@ -20,7 +20,7 @@ import os
 from typing import Optional
 from uuid import uuid4
 
-import requests
+import aiohttp
 from etos_lib import ETOS
 from etos_lib.kubernetes import Kubernetes
 from etos_lib.kubernetes import TestRun as TestRunClient
@@ -85,12 +85,13 @@ class TestRun:
         self.logger.info("Downloading test suite %r", url)
         self.span.set_attribute("etos.test_suite.uri", url)
         try:
-            response = requests.get(url, timeout=60)
-            response.raise_for_status()
+            async with aiohttp.ClientSession() as session:
+                async with session.get(url, timeout=60, raise_for_status=True) as response:
+                    content = await response.read()
         except Exception as exception:  # pylint:disable=broad-except
             raise AssertionError(f"Unable to download suite from {url}") from exception
         self.logger.info("Test suite downloaded")
-        return safe_load(response.content)
+        return safe_load(content)
 
     async def validate_suite(self, test_suite: dict) -> MinimalSpec:
         """Validate the test suite against the MinimalSpec schema."""
@@ -110,9 +111,9 @@ class TestRun:
                 test_runner = execution.environment.testRunner
                 if test_runner in checked:
                     continue
-                assert (
-                    await docker.digest(test_runner) is not None
-                ), f"Test runner {test_runner} not found"
+                assert await docker.digest(test_runner) is not None, (
+                    f"Test runner {test_runner} not found"
+                )
                 checked.add(test_runner)
         return testrun
 

--- a/python/src/etos_api/routers/v1beta1/testrun.py
+++ b/python/src/etos_api/routers/v1beta1/testrun.py
@@ -110,9 +110,9 @@ class TestRun:
                 test_runner = execution.environment.testRunner
                 if test_runner in checked:
                     continue
-                assert await docker.digest(test_runner) is not None, (
-                    f"Test runner {test_runner} not found"
-                )
+                assert (
+                    await docker.digest(test_runner) is not None
+                ), f"Test runner {test_runner} not found"
                 checked.add(test_runner)
         return testrun
 

--- a/python/src/etos_api/routers/v1beta1/testrun.py
+++ b/python/src/etos_api/routers/v1beta1/testrun.py
@@ -24,9 +24,9 @@ import requests
 from etos_lib import ETOS
 from etos_lib.kubernetes import Kubernetes
 from etos_lib.kubernetes import TestRun as TestRunClient
-from etos_lib.kubernetes.schemas.v1beta1_testrun import Metadata, Providers, Retention, Suite
-from etos_lib.kubernetes.schemas.v1beta1_testrun import TestRun as TestRunSchema
-from etos_lib.kubernetes.schemas.v1beta1_testrun import TestRunSpec
+from etos_lib.kubernetes.schemas.v1beta1.testrun import Metadata, Providers, Retention, Suite
+from etos_lib.kubernetes.schemas.v1beta1.testrun import TestRun as TestRunSchema
+from etos_lib.kubernetes.schemas.v1beta1.testrun import TestRunSpec
 from fastapi import HTTPException
 from opentelemetry import baggage as otel_baggage
 from opentelemetry import context as otel_context
@@ -110,9 +110,9 @@ class TestRun:
                 test_runner = execution.environment.testRunner
                 if test_runner in checked:
                     continue
-                assert (
-                    await docker.digest(test_runner) is not None
-                ), f"Test runner {test_runner} not found"
+                assert await docker.digest(test_runner) is not None, (
+                    f"Test runner {test_runner} not found"
+                )
                 checked.add(test_runner)
         return testrun
 

--- a/python/src/etos_api/routers/v1beta1/utilities.py
+++ b/python/src/etos_api/routers/v1beta1/utilities.py
@@ -1,0 +1,98 @@
+# Copyright Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utilities specific for the testrun endpoint."""
+
+import asyncio
+import logging
+import re
+import time
+
+from etos_api.library.graphql import GraphqlQueryHandler
+from etos_api.library.graphql_queries import (ARTIFACT_IDENTITY_QUERY,
+                                              VERIFY_ARTIFACT_ID_EXISTS)
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def wait_for_artifact_created(etos_library, artifact_identity, artifact_id, timeout=30):
+    """Execute graphql query and wait for an artifact created.
+
+    :param etos_library: ETOS library instande.
+    :type etos_library: :obj:`etos_lib.etos.ETOS`
+    :param artifact_identity: Identity of the artifact to get.
+    :type artifact_identity: str
+    :param artifact_id: ID of the artifact to get.
+    :type artifact_id: UUID
+    :param timeout: Maximum time to wait for a response (seconds).
+    :type timeout: int
+    :return: ArtifactCreated edges from GraphQL.
+    :rtype: list
+    """
+    timeout = time.time() + timeout
+    query_handler = GraphqlQueryHandler(etos_library)
+    if artifact_id is not None:
+        LOGGER.info("Verify that artifact ID %r exists.", artifact_id)
+        query = VERIFY_ARTIFACT_ID_EXISTS
+    elif artifact_identity is not None:
+        LOGGER.info("Getting artifact from packageURL %r", artifact_identity)
+        query = ARTIFACT_IDENTITY_QUERY
+        if artifact_identity.startswith("pkg:"):
+            # This makes the '$regex' query to the event repository more efficient.
+            artifact_identity = f"^{artifact_identity}"
+    else:
+        raise ValueError("'artifact_id' and 'artifact_identity' are both None!")
+    artifact_identifier = artifact_identity or str(artifact_id)
+
+    LOGGER.debug("Wait for artifact created event.")
+    while time.time() < timeout:
+        try:
+            artifacts = await query_handler.execute(query % artifact_identifier)
+            assert artifacts is not None
+            assert artifacts["artifactCreated"]["edges"]
+            return artifacts["artifactCreated"]["edges"]
+        except (AssertionError, KeyError):
+            LOGGER.warning("Artifact created not ready yet")
+        await asyncio.sleep(2)
+    LOGGER.error("Artifact %r not found.", artifact_identifier)
+    return None
+
+
+def convert_to_rfc1123(value: str) -> str:
+    """Convert string to RFC-1123 accepted string.
+
+    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+
+    Some resource types require their names to follow the DNS label standard as defined in RFC 1123.
+    This means the name must:
+
+        contain at most 63 characters
+        contain only lowercase alphanumeric characters or '-'
+        start with an alphanumeric character
+        end with an alphanumeric character
+
+    This method does not care about the length of the string since ETOS uses generateName for
+    creating Kubernetes resources and that function will truncate the string down to 63-5 and
+    then add 5 random characters.
+    """
+    # Replace all characters that are not alphanumeric (A-Z, a-z, 0-9) with a hyphen
+    result = re.sub(r"[^A-Z\d]", "-", value, flags=re.IGNORECASE)
+    # Remove leading hyphens
+    result = re.sub(r"^-+", "", result)
+    # Remove trailing hyphens
+    result = re.sub(r"-+$", "", result)
+    # Replace multiple consecutive hyphens with a single hyphen
+    result = re.sub(r"-+", "-", result)
+    return result.lower()

--- a/python/src/etos_api/routers/v1beta1/utilities.py
+++ b/python/src/etos_api/routers/v1beta1/utilities.py
@@ -21,8 +21,7 @@ import re
 import time
 
 from etos_api.library.graphql import GraphqlQueryHandler
-from etos_api.library.graphql_queries import (ARTIFACT_IDENTITY_QUERY,
-                                              VERIFY_ARTIFACT_ID_EXISTS)
+from etos_api.library.graphql_queries import ARTIFACT_IDENTITY_QUERY, VERIFY_ARTIFACT_ID_EXISTS
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->
eiffel-community/etos#661
depends-on: eiffel-community/etos-library#68

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
We also updated to using v1beta1 Environments when getting sub suites. To use this the ETR needs a rather large change in order to read this new format. However, all providers are currently hard-coding v1alpha on the ETOS API URL so it will still work even if v1beta1 testruns are started.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->
Providers are hard-coding the v1alpha endpoint for getting sub suites so the new function created in this change will not be used. This means that the ETR will be using the endpoint that fetches v1alpha Environment and then convert it to the old TERCC format from v0.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
